### PR TITLE
cli: qr --member loads the installed service environment; help strings for setup and doctor (#6)

### DIFF
--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -28,7 +28,7 @@ caty-gateway setup --member me --backend claude               # サービス設�
 | `setup --member <id> --backend <b> [--port N] [--public-url URL] [--plan-only] [--no-history] [--reset]` | preflight から QR 表示までの一括セットアップ。`--plan-only` は計画表示のみ |
 | `status --member <id> [--wait]` | セットアップ／supervisor の進行状態 |
 | `serve` | フォアグラウンド起動。サービスから呼ばれる実体。非 loopback bind で `CATY_TOKEN` が空なら起動を拒否（fail-closed） |
-| `qr [--qr-delivery auto\|tty\|url]` | ペアリング QR の再発行 |
+| `qr [--member <id>] [--qr-delivery auto\|tty\|url]` | ペアリング QR の再発行 |
 | `push open-url\|media …` | 接続中のクライアントに URL や画像を開かせる。詳細は [push.md](push.md) |
 | `doctor --backend <b>` | backend 別 preflight を単独実行。受動チェックのみで AI にプロンプトは送らない |
 
@@ -125,24 +125,17 @@ Issue ラベルの `component:*` は、この表の行と 1 対 1 です。
 
 ### QR の再発行
 
-`caty-gateway qr` は、サービスと同じ環境変数（少なくとも `CATY_ID` `CATY_GATEWAY_PORT` `CATY_TOKEN` `CATY_PUBLIC_URL`）を必要とします。新しいターミナルにはそれが無いので、先に読み込みます。
-
-Linux（環境ファイルを読み込む）:
+インストール済みメンバーの環境変数（トークン、ポート、公開 URL など）を読み込んで再発行します。
 
 ```sh
-set -a; . ~/.config/caty-gateway/<id>.env; set +a
-caty-gateway qr
+caty-gateway qr --member <id>
+# ブラウザで表示する場合:
+caty-gateway qr --member <id> --qr-delivery url
 ```
 
-macOS（環境変数は plist の中にあるので取り出す。**このリリースでは通しの実測なし**。`plutil -extract` 自体はテンプレートで確認済み）:
+Linux では `~/.config/caty-gateway/<id>.env`、macOS では `~/Library/LaunchAgents/ai.caty.gateway.<id>.plist` の `EnvironmentVariables` を読み込みます。`PATH` を除き、インストール済みの値がシェルの環境変数を上書きします。設定ファイルの欠落・不正や `CATY_TOKEN` の欠落時は、ゲートウェイ本体を読み込む前にエラー終了します。
 
-```sh
-P=~/Library/LaunchAgents/ai.caty.gateway.<id>.plist
-for k in CATY_ID CATY_GATEWAY_PORT CATY_TOKEN CATY_PUBLIC_URL; do export $k="$(plutil -extract EnvironmentVariables.$k raw "$P")"; done
-caty-gateway qr
-```
-
-`qr --member <id>` で環境を自動で読む改善は別 Issue で扱います。
+手動での読み込みも引き続き利用できます。サービスの環境変数を export したうえで、`--member` なしの `caty-gateway qr` を実行してください。
 
 <a id="uninstall"></a>
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -28,7 +28,7 @@ caty-gateway setup --member me --backend claude               # install service 
 | `setup --member <id> --backend <b> [--port N] [--public-url URL] [--plan-only] [--no-history] [--reset]` | One-shot setup from preflight through showing the QR. `--plan-only` only displays the plan |
 | `status --member <id> [--wait]` | Progress of setup / supervisor |
 | `serve` | Foreground start. This is the actual process the service invokes. Refuses to start on a non-loopback bind if `CATY_TOKEN` is empty (fail-closed) |
-| `qr [--qr-delivery auto\|tty\|url]` | Reissue the pairing QR |
+| `qr [--member <id>] [--qr-delivery auto\|tty\|url]` | Reissue the pairing QR |
 | `push open-url\|media …` | Makes a connected client open a URL or image. See [push.md](push.md) for details |
 | `doctor --backend <b>` | Runs backend-specific preflight on its own. Passive checks only; never sends a prompt to the AI |
 
@@ -125,24 +125,17 @@ The service uses `KeepAlive` / `Restart=always` and restarts within 5 seconds if
 
 ### Reissuing the QR
 
-`caty-gateway qr` needs the same environment variables as the service (at least `CATY_ID`, `CATY_GATEWAY_PORT`, `CATY_TOKEN`, `CATY_PUBLIC_URL`). A fresh terminal does not have them, so load them first.
-
-Linux (source the environment file):
+Use the installed member's environment, including its token, port, and public URL:
 
 ```sh
-set -a; . ~/.config/caty-gateway/<id>.env; set +a
-caty-gateway qr
+caty-gateway qr --member <id>
+# For a browser-viewable QR:
+caty-gateway qr --member <id> --qr-delivery url
 ```
 
-macOS (the variables live inside the plist, so extract them; **not measured end-to-end in this release**, `plutil -extract` itself verified against the template):
+On Linux, this reads `~/.config/caty-gateway/<id>.env`; on macOS, it reads `EnvironmentVariables` from `~/Library/LaunchAgents/ai.caty.gateway.<id>.plist`. Installed values override the current shell environment except for `PATH`. Missing or invalid configuration, including a missing `CATY_TOKEN`, exits with an error before the gateway runtime loads.
 
-```sh
-P=~/Library/LaunchAgents/ai.caty.gateway.<id>.plist
-for k in CATY_ID CATY_GATEWAY_PORT CATY_TOKEN CATY_PUBLIC_URL; do export $k="$(plutil -extract EnvironmentVariables.$k raw "$P")"; done
-caty-gateway qr
-```
-
-A `qr --member <id>` option that loads the environment automatically is tracked in a separate issue.
+Manual sourcing still works: export the service environment and run `caty-gateway qr` without `--member`.
 
 <a id="uninstall"></a>
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -124,7 +124,7 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | FISH_RETRY_CAP_S | 8.0 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:148; src/caty_gateway/tts_fish.py:211 |
 | FISH_UNHEALTHY_COOLDOWN_S | 20.0 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:62 |
 | HERMES_HOME | expression: str(self.home / '.hermes') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:717 |
-| HOME | expression: str(Path.home()); expression: str(pathlib.Path.home()) | D | local | process-only | src/caty_gateway/cli.py:60; src/caty_gateway/doctor.py:102; src/caty_gateway/setup_orchestrator.py:118 |
+| HOME | None (unset); expression: str(Path.home()); expression: str(pathlib.Path.home()) | D | local | process-only | src/caty_gateway/cli.py:60; src/caty_gateway/doctor.py:102; src/caty_gateway/setup_orchestrator.py:118 |
 | OPENCLAW_BIN | 'openclaw' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:166; src/caty_gateway/doctor.py:225 |
 | OPENCLAW_GATEWAY_TOKEN | None (unset) | B | secret | member env (0600) | src/caty_gateway/backends/openclaw.py:138; src/caty_gateway/doctor.py:231 |
 | OPENCLAW_HOME | expression: str(self.home / '.openclaw') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:714 |

--- a/docs/env.md
+++ b/docs/env.md
@@ -18,16 +18,16 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | ANTHROPIC_API_KEY | None (unset) | C | secret | member env (0600) | src/caty_gateway/vision_describer.py:46 |
 | CATY_ACCENT_COLOR | '#FF8FB1'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:187; src/caty_gateway/setup_orchestrator.py:127 |
 | CATY_ADMIN_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:184 |
-| CATY_AGENT | 'main' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:130; src/caty_gateway/doctor.py:227; src/caty_gateway/setup_orchestrator.py:1139 |
+| CATY_AGENT | 'main' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:130; src/caty_gateway/doctor.py:227; src/caty_gateway/setup_orchestrator.py:1159 |
 | CATY_ASSETS_VERSION | '1' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:188 |
 | CATY_ASSET_DIR | expression: str(resources.files('caty_gateway').joinpath('assets')) | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:189 |
 | CATY_AVATAR_STYLE_REF | None (unset) | C | local | member env (0600) | src/caty_gateway/avatar_engine.py:525 |
 | CATY_AVATAR_VENDOR_HOST_ALLOWLIST | '' | C | public | member env (0600) | src/caty_gateway/caty_config.py:42 |
 | CATY_AVATAR_WORKDIR | None (unset) | C | local | member env (0600) | src/caty_gateway/avatar_engine.py:527 |
 | CATY_BACKEND | 'openclaw' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:131; src/caty_gateway/setup_orchestrator.py:122 |
-| CATY_BACKEND_CONFIG_PATHS | '' | D | local | process-only | src/caty_gateway/setup_orchestrator.py:702 |
-| CATY_BACKEND_ENABLE_CMD | '' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1061 |
-| CATY_CLAUDE_BIN | 'claude' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:168; src/caty_gateway/doctor.py:216; src/caty_gateway/setup_orchestrator.py:672 |
+| CATY_BACKEND_CONFIG_PATHS | '' | D | local | process-only | src/caty_gateway/setup_orchestrator.py:722 |
+| CATY_BACKEND_ENABLE_CMD | '' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1081 |
+| CATY_CLAUDE_BIN | 'claude' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:168; src/caty_gateway/doctor.py:216; src/caty_gateway/setup_orchestrator.py:692 |
 | CATY_CLAUDE_CWD | expression: os.path.expanduser('~'); expression: str(self.home) | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:170; src/caty_gateway/doctor.py:217 |
 | CATY_CLAUDE_MODEL | '' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:169 |
 | CATY_CLAUDE_PROJECTS_DIR | None (unset) | B | local | member env (0600) | src/caty_gateway/backends/claude.py:118 |
@@ -36,7 +36,7 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_EXTERNAL_SEED_TURNS | '50' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1342 |
 | CATY_EXTERNAL_SESSIONS | False | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1350 |
 | CATY_FILLER_DIR | None (unset) | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:1863 |
-| CATY_GATEWAY_BIND | ''; '0.0.0.0' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:125; src/caty_gateway/cli.py:48 |
+| CATY_GATEWAY_BIND | ''; '0.0.0.0' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:125; src/caty_gateway/cli.py:94 |
 | CATY_GATEWAY_PORT | '8788' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:128; src/caty_gateway/doctor.py:289; src/caty_gateway/setup_orchestrator.py:174 |
 | CATY_GATEWAY_TOKEN | None (unset) | B | secret | member env (0600) | src/caty_gateway/backends/openclaw.py:138; src/caty_gateway/doctor.py:231 |
 | CATY_GATEWAY_URL | 'http://127.0.0.1:18789' | B | local | member env (0600) | src/caty_gateway/backends/openclaw.py:296; src/caty_gateway/doctor.py:241 |
@@ -48,16 +48,16 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_GCLI_PARSE_SPEC | None (unset) | B | public | member env (0600) | src/caty_gateway/backends/generic_cli.py:95 |
 | CATY_GCLI_RESUME_ARGS | None (unset) | B | public | member env (0600) | src/caty_gateway/backends/generic_cli.py:91 |
 | CATY_GCLI_SESSION_STORE | None (unset) | B | local | member env (0600) | src/caty_gateway/backends/generic_cli.py:99 |
-| CATY_HERMES_API_KEY | ''; None (unset) | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:172; src/caty_gateway/doctor.py:244; src/caty_gateway/setup_orchestrator.py:565; src/caty_gateway/setup_orchestrator.py:568; src/caty_gateway/setup_orchestrator.py:681 |
+| CATY_HERMES_API_KEY | ''; None (unset) | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:172; src/caty_gateway/doctor.py:244; src/caty_gateway/setup_orchestrator.py:585; src/caty_gateway/setup_orchestrator.py:588; src/caty_gateway/setup_orchestrator.py:701 |
 | CATY_HERMES_URL | 'http://127.0.0.1:8642' | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:171; src/caty_gateway/doctor.py:246 |
 | CATY_HISTORY_DIR | '' | A | local | member env (0600) | src/caty_gateway/history_store.py:27; src/caty_gateway/history_store.py:31; src/caty_gateway/session_links.py:21 |
 | CATY_HISTORY_MAX_TURNS | '0' | C | public | member env (0600) | src/caty_gateway/history_store.py:114 |
 | CATY_HISTORY_MD | '1' | C | public | member env (0600) | src/caty_gateway/history_store.py:216 |
-| CATY_ID | ''; 'caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_config.py:114; src/caty_gateway/caty_gateway.py:1310; src/caty_gateway/caty_gateway.py:1366; src/caty_gateway/caty_gateway.py:185; src/caty_gateway/caty_gateway.py:1862; src/caty_gateway/caty_gateway.py:2036; src/caty_gateway/caty_gateway.py:4531; src/caty_gateway/pairing_store.py:144; src/caty_gateway/share_store.py:115 |
-| CATY_LANG | 'ja' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:165; src/caty_gateway/setup_orchestrator.py:1140 |
+| CATY_ID | ''; 'caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_config.py:114; src/caty_gateway/caty_gateway.py:1310; src/caty_gateway/caty_gateway.py:1366; src/caty_gateway/caty_gateway.py:185; src/caty_gateway/caty_gateway.py:1862; src/caty_gateway/caty_gateway.py:2036; src/caty_gateway/caty_gateway.py:4534; src/caty_gateway/pairing_store.py:144; src/caty_gateway/share_store.py:115 |
+| CATY_LANG | 'ja' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:165; src/caty_gateway/setup_orchestrator.py:1160 |
 | CATY_NAME | 'Caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/avatar_engine.py:551; src/caty_gateway/caty_gateway.py:186; src/caty_gateway/history_store.py:202; src/caty_gateway/setup_orchestrator.py:126 |
 | CATY_OFFLINE | '' | C | public | member env (0600) | src/caty_gateway/voice_preview.py:51 |
-| CATY_OPENAI_API_KEY | '' | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:175; src/caty_gateway/doctor.py:251; src/caty_gateway/setup_orchestrator.py:681 |
+| CATY_OPENAI_API_KEY | '' | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:175; src/caty_gateway/doctor.py:251; src/caty_gateway/setup_orchestrator.py:701 |
 | CATY_OPENAI_BASE_URL | '' | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:173; src/caty_gateway/doctor.py:249 |
 | CATY_OPENAI_CHAT_HEARTBEAT_SEC | '5' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:215 |
 | CATY_OPENAI_CHAT_MAX_CONCURRENCY | '2' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:214 |
@@ -76,20 +76,20 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_PRESENCE_MODE2 | '' | C | public | member env (0600) | src/caty_gateway/presence_state.py:8 |
 | CATY_PTT_BRAIN_TIMEOUT | '1800' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:181 |
 | CATY_PTT_JOB_TTL | '2100' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:182 |
-| CATY_PUBLIC_URL | '' | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:2489; src/caty_gateway/caty_gateway.py:2681; src/caty_gateway/doctor.py:105; src/caty_gateway/setup_orchestrator.py:128 |
+| CATY_PUBLIC_URL | '' | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:2489; src/caty_gateway/caty_gateway.py:2684; src/caty_gateway/doctor.py:105; src/caty_gateway/setup_orchestrator.py:128 |
 | CATY_QR_DELIVERY | 'auto' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:2610; src/caty_gateway/setup_orchestrator.py:129 |
 | CATY_REQUIRE_AUTH | False | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1354 |
 | CATY_SESSION_KEY_PREFIX | 'caty-' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:158 |
-| CATY_SETUP_BACKEND_RECOVERY_TIMEOUT_SECONDS | '120' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:925 |
-| CATY_SETUP_DEBUG | None (unset) | C | public | process-only | src/caty_gateway/setup_orchestrator.py:2074 |
-| CATY_SETUP_HANDOFF_GRACE_SECONDS | '5' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1629 |
-| CATY_SETUP_QR_TIMEOUT_SECONDS | '3700' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1396 |
+| CATY_SETUP_BACKEND_RECOVERY_TIMEOUT_SECONDS | '120' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:945 |
+| CATY_SETUP_DEBUG | None (unset) | C | public | process-only | src/caty_gateway/setup_orchestrator.py:2094 |
+| CATY_SETUP_HANDOFF_GRACE_SECONDS | '5' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1649 |
+| CATY_SETUP_QR_TIMEOUT_SECONDS | '3700' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1416 |
 | CATY_SETUP_RESUME_TTL_SECONDS | None (unset) | D | public | process-only | src/caty_gateway/setup_orchestrator.py:130 |
-| CATY_SETUP_STATUS_WAIT_SECONDS | '600' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1771 |
-| CATY_SETUP_SUPERVISED | None (unset) | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1059; src/caty_gateway/setup_orchestrator.py:1556; src/caty_gateway/setup_orchestrator.py:1660; src/caty_gateway/setup_orchestrator.py:1824; src/caty_gateway/setup_orchestrator.py:1876; src/caty_gateway/setup_orchestrator.py:2005 |
+| CATY_SETUP_STATUS_WAIT_SECONDS | '600' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1791 |
+| CATY_SETUP_SUPERVISED | None (unset) | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1079; src/caty_gateway/setup_orchestrator.py:1576; src/caty_gateway/setup_orchestrator.py:1680; src/caty_gateway/setup_orchestrator.py:1844; src/caty_gateway/setup_orchestrator.py:1896; src/caty_gateway/setup_orchestrator.py:2025 |
 | CATY_SHARE_DIR | '' | A | local | member env (0600) | src/caty_gateway/share_store.py:126 |
 | CATY_STREAM_TTS | ''; None (unset) | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1384; src/caty_gateway/caty_gateway.py:162 |
-| CATY_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:183; src/caty_gateway/caty_gateway.py:4932; src/caty_gateway/cli.py:49 |
+| CATY_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:183; src/caty_gateway/caty_gateway.py:4935; src/caty_gateway/cli.py:95 |
 | CATY_TOMBSTONE_TTL_DAYS | '7' | C | public | member env (0600) | src/caty_gateway/history_store.py:139 |
 | CATY_TTS_ENGINE | '' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1502 |
 | CATY_TTS_PROXY | 'http://localhost:5100/v1/audio/speech' | C | local | member env (0600) | src/caty_gateway/caty_gateway.py:179 |
@@ -123,17 +123,17 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | FISH_RETRY_BASE_S | 0.5 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:147; src/caty_gateway/tts_fish.py:210 |
 | FISH_RETRY_CAP_S | 8.0 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:148; src/caty_gateway/tts_fish.py:211 |
 | FISH_UNHEALTHY_COOLDOWN_S | 20.0 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:62 |
-| HERMES_HOME | expression: str(self.home / '.hermes') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:697 |
-| HOME | expression: str(Path.home()); expression: str(pathlib.Path.home()) | D | local | process-only | src/caty_gateway/doctor.py:102; src/caty_gateway/setup_orchestrator.py:118 |
+| HERMES_HOME | expression: str(self.home / '.hermes') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:717 |
+| HOME | expression: str(Path.home()); expression: str(pathlib.Path.home()) | D | local | process-only | src/caty_gateway/cli.py:60; src/caty_gateway/doctor.py:102; src/caty_gateway/setup_orchestrator.py:118 |
 | OPENCLAW_BIN | 'openclaw' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:166; src/caty_gateway/doctor.py:225 |
 | OPENCLAW_GATEWAY_TOKEN | None (unset) | B | secret | member env (0600) | src/caty_gateway/backends/openclaw.py:138; src/caty_gateway/doctor.py:231 |
-| OPENCLAW_HOME | expression: str(self.home / '.openclaw') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:694 |
-| PATH | None (unset); expression: os.defpath | D | local | process-only | src/caty_gateway/doctor.py:122; src/caty_gateway/setup_orchestrator.py:1137; src/caty_gateway/setup_orchestrator.py:235 |
+| OPENCLAW_HOME | expression: str(self.home / '.openclaw') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:714 |
+| PATH | None (unset); expression: os.defpath | D | local | process-only | src/caty_gateway/doctor.py:122; src/caty_gateway/setup_orchestrator.py:1157; src/caty_gateway/setup_orchestrator.py:235 |
 | POYO_API_KEY | None (unset) | C | secret | member env (0600) | src/caty_gateway/avatar_engine.py:141 |
 | POYO_BASE | None (unset) | C | public | member env (0600) | src/caty_gateway/avatar_engine.py:144 |
 | PYTHON | None (unset) | D | local | process-only | src/caty_gateway/doctor.py:106; src/caty_gateway/setup_orchestrator.py:137 |
 | RENOISE_API_KEY | None (unset) | C | secret | member env (0600) | src/caty_gateway/avatar_engine.py:339 |
 | RENOISE_AUTH_TOKEN | None (unset) | C | secret | member env (0600) | src/caty_gateway/avatar_engine.py:340 |
 | RENOISE_BASE_URL | None (unset) | C | public | member env (0600) | src/caty_gateway/avatar_engine.py:343 |
-| XDG_RUNTIME_DIR | None (unset) | D | local | process-only | src/caty_gateway/setup_orchestrator.py:586 |
-| XDG_STATE_HOME | ''; expression: str(self.home / '.local' / 'state') | D | local | process-only | src/caty_gateway/doctor.py:208; src/caty_gateway/pairing_store.py:162; src/caty_gateway/setup_orchestrator.py:1151; src/caty_gateway/setup_orchestrator.py:195; src/caty_gateway/share_store.py:129 |
+| XDG_RUNTIME_DIR | None (unset) | D | local | process-only | src/caty_gateway/setup_orchestrator.py:606 |
+| XDG_STATE_HOME | ''; expression: str(self.home / '.local' / 'state') | D | local | process-only | src/caty_gateway/doctor.py:208; src/caty_gateway/pairing_store.py:162; src/caty_gateway/setup_orchestrator.py:1171; src/caty_gateway/setup_orchestrator.py:195; src/caty_gateway/share_store.py:129 |

--- a/docs/reference.ja.md
+++ b/docs/reference.ja.md
@@ -44,7 +44,7 @@ caty-gateway setup --member MEMBER [--backend BACKEND] [--port PORT] [--name NAM
 |---|---|
 | `status --member MEMBER [--wait]` | セットアップ／supervisor の状態 |
 | `serve` | フォアグラウンド起動。`CATY_GATEWAY_BIND` が loopback 以外で `CATY_TOKEN` が空なら起動前に終了 |
-| `qr [--qr-delivery {auto,tty,url}] [--wait-visible-seconds N]` | ペアリング QR の再発行 |
+| `qr [--member MEMBER] [--qr-delivery {auto,tty,url}] [--wait-visible-seconds N]` | ペアリング QR の再発行。`--member` は Linux の環境ファイルまたは macOS の plist から設定を読み込み、`PATH` を除いてシェルの値を上書き |
 | `push open-url URL --title T [--audience A] [--session S] [--key K]` / `push media URL --title T …` | 接続中クライアントへのイベント送出。`--title` は必須。`CATY_TOKEN` は環境変数で渡す |
 | `doctor --backend BACKEND [--member MEMBER] [--port PORT] [--public-url URL]` | 受動 preflight。`--probe` は予約済み（このリリースでは FAIL を返す） |
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,7 +44,7 @@ The generated `CATY_TOKEN` is only generated during install, and shows as `[REDA
 |---|---|
 | `status --member MEMBER [--wait]` | State of setup / supervisor |
 | `serve` | Foreground start. Exits before starting if `CATY_GATEWAY_BIND` is not loopback and `CATY_TOKEN` is empty |
-| `qr [--qr-delivery {auto,tty,url}] [--wait-visible-seconds N]` | Reissue the pairing QR |
+| `qr [--member MEMBER] [--qr-delivery {auto,tty,url}] [--wait-visible-seconds N]` | Reissue the pairing QR; `--member` loads the installed Linux env file or macOS plist environment (except `PATH`), overriding shell values |
 | `push open-url URL --title T [--audience A] [--session S] [--key K]` / `push media URL --title T …` | Send an event to connected clients. `--title` is required. `CATY_TOKEN` is passed via an environment variable |
 | `doctor --backend BACKEND [--member MEMBER] [--port PORT] [--public-url URL]` | Passive preflight. `--probe` is reserved (returns FAIL in this release) |
 

--- a/src/caty_gateway/caty_gateway.py
+++ b/src/caty_gateway/caty_gateway.py
@@ -2619,6 +2619,9 @@ def _qr_delivery_mode(cli_value=None, stdout=None):
 
 
 def _qr_cli_args(argv):
+    if any(arg == "--member" or arg.startswith("--member=") for arg in argv):
+        print("ERROR: --member requires the public CLI: caty-gateway qr --member ID", file=sys.stderr)
+        raise SystemExit(2)
     parser = argparse.ArgumentParser(prog="caty_gateway.py qr")
     parser.add_argument("--qr-delivery", choices=QR_DELIVERY_MODES)
     parser.add_argument("--wait-visible-seconds", type=int)

--- a/src/caty_gateway/cli.py
+++ b/src/caty_gateway/cli.py
@@ -2,6 +2,8 @@
 
 import argparse
 import os
+import pathlib
+import platform
 import sys
 
 
@@ -10,16 +12,17 @@ def build_parser():
 
     parser = argparse.ArgumentParser(prog="caty-gateway", description="Set up and run a Caty gateway")
     commands = parser.add_subparsers(dest="command")
-    commands.add_parser("setup", parents=[setup_orchestrator.SetupOrchestrator._parser()], add_help=False)
+    commands.add_parser("setup", help="Install, start, verify, and pair one gateway member", parents=[setup_orchestrator.SetupOrchestrator._parser()], add_help=False)
     status = commands.add_parser("status", help="Show setup progress")
     status.add_argument("--member", required=True)
     status.add_argument("--wait", action="store_true")
     commands.add_parser("serve", help="Run the gateway in the foreground")
-    qr = commands.add_parser("qr", help="Create a pairing QR code")
+    qr = commands.add_parser("qr", help="Reissue the pairing QR (use --member to load the installed service environment)")
+    qr.add_argument("--member", help="Load the installed service environment for this member")
     qr.add_argument("--qr-delivery", choices=("auto", "tty", "url"))
     qr.add_argument("--wait-visible-seconds", type=float)
     commands.add_parser("push", help="Send a gateway event", add_help=False)
-    commands.add_parser("doctor", parents=[doctor.build_parser()], add_help=False)
+    commands.add_parser("doctor", help="Passive preflight for a backend, port, and public URL", parents=[doctor.build_parser()], add_help=False)
     return parser
 
 
@@ -43,6 +46,49 @@ def main(argv=None):
     if args.command == "doctor":
         from caty_gateway.doctor import main as doctor_main
         return doctor_main(argv[1:])
+    if args.command == "qr" and args.member is not None:
+        from caty_gateway.setup_orchestrator import MEMBER_RE, member_artifact_path, read_member_env
+
+        system = platform.system()
+        if system not in ("Linux", "Darwin"):
+            print(
+                f"ERROR: unsupported platform {system!r}; "
+                "caty-gateway qr --member supports Linux and macOS",
+                file=sys.stderr,
+            )
+            return 2
+        home = pathlib.Path(os.environ.get("HOME", str(pathlib.Path.home()))).expanduser()
+        if not MEMBER_RE.fullmatch(args.member) or args.member in {".", ".."}:
+            print(
+                f"ERROR: invalid member identifier {args.member!r}; "
+                "run caty-gateway setup --member MEMBER first",
+                file=sys.stderr,
+            )
+            return 2
+        path = member_artifact_path(args.member, home, system)
+        try:
+            values = read_member_env(path, system)
+            if not values.get("CATY_TOKEN", "").strip():
+                raise ValueError("missing token")
+            os.environ.update({key: value for key, value in values.items() if key != "PATH"})
+        except Exception:  # Parser errors may contain service secrets; never echo them.
+            safe_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
+            print(
+                f"ERROR: no installed environment for member {args.member!r} at {safe_path}; "
+                f"run caty-gateway setup --member {args.member} first",
+                file=sys.stderr,
+            )
+            return 2
+        # Forward the runtime flags verbatim, removing only the public option.
+        tail = iter(argv[1:])
+        argv = ["qr"]
+        for flag in tail:
+            option, separator, _ = flag.partition("=")
+            if option.startswith("--") and "--member".startswith(option):
+                if not separator:
+                    next(tail)
+            else:
+                argv.append(flag)
     if args.command == "serve":
         # Reject before runtime imports can initialize a configured backend.
         host = os.environ.get("CATY_GATEWAY_BIND", "").strip() or "0.0.0.0"

--- a/src/caty_gateway/cli.py
+++ b/src/caty_gateway/cli.py
@@ -57,7 +57,7 @@ def main(argv=None):
                 file=sys.stderr,
             )
             return 2
-        home = pathlib.Path(os.environ.get("HOME", str(pathlib.Path.home()))).expanduser()
+        home = pathlib.Path(os.environ.get("HOME") or str(pathlib.Path.home())).expanduser()
         if not MEMBER_RE.fullmatch(args.member) or args.member in {".", ".."}:
             print(
                 f"ERROR: invalid member identifier {args.member!r}; "
@@ -74,8 +74,8 @@ def main(argv=None):
         except Exception:  # Parser errors may contain service secrets; never echo them.
             safe_path = str(path).replace("\r", "\\r").replace("\n", "\\n")
             print(
-                f"ERROR: no installed environment for member {args.member!r} at {safe_path}; "
-                f"run caty-gateway setup --member {args.member} first",
+                f"ERROR: invalid installed environment for member {args.member!r} at {safe_path} (unreadable, malformed, or missing CATY_TOKEN); rerun caty-gateway setup --member {args.member}"
+                if os.path.exists(path) else f"ERROR: no installed environment for member {args.member!r} at {safe_path}; run caty-gateway setup --member {args.member} first",
                 file=sys.stderr,
             )
             return 2
@@ -86,7 +86,7 @@ def main(argv=None):
             option, separator, _ = flag.partition("=")
             if option.startswith("--") and "--member".startswith(option):
                 if not separator:
-                    next(tail)
+                    next(tail, None)
             else:
                 argv.append(flag)
     if args.command == "serve":

--- a/src/caty_gateway/setup_orchestrator.py
+++ b/src/caty_gateway/setup_orchestrator.py
@@ -198,12 +198,12 @@ class SetupOrchestrator:
     def _platform_paths(self) -> Tuple[pathlib.Path, str]:
         if self.system == "Linux":
             return (
-                self.home / ".config" / "caty-gateway" / (self.member + ".env"),
+                member_artifact_path(self.member, self.home, self.system),
                 "caty-gateway-" + self.member + ".service",
             )
         if self.system == "Darwin":
             label = "ai.caty.gateway." + self.member
-            return self.home / "Library" / "LaunchAgents" / (label + ".plist"), label
+            return member_artifact_path(self.member, self.home, self.system), label
         return pathlib.Path("/__unsupported__"), ""
 
     def _run(
@@ -459,7 +459,8 @@ class SetupOrchestrator:
         self._write_state()
         return True
 
-    def _read_env_file(self, path: pathlib.Path) -> Dict[str, str]:
+    @staticmethod
+    def _read_env_file(path: pathlib.Path, *, strict: bool = False) -> Dict[str, str]:
         values: Dict[str, str] = {}
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
@@ -467,10 +468,25 @@ class SetupOrchestrator:
             return values
         for line in lines:
             stripped = line.strip()
-            if not stripped or stripped.startswith("#") or "=" not in stripped:
+            if not stripped or stripped.startswith("#"):
+                continue
+            if "=" not in stripped:
+                if strict:
+                    raise ValueError("invalid environment assignment")
                 continue
             key, value = stripped.split("=", 1)
             value = value.strip()
+            quoted = value[:1] in ("'", '"')
+            closing_quote_escaped = (
+                value.startswith('"')
+                and len(value) >= 2
+                and (len(value[:-1]) - len(value[:-1].rstrip("\\"))) % 2 == 1
+            )
+            if strict and (
+                not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key.strip())
+                or (quoted and (len(value) < 2 or value[-1] != value[0] or closing_quote_escaped))
+            ):
+                raise ValueError("invalid environment assignment")
             if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
                 quote = value[0]
                 value = value[1:-1]
@@ -480,10 +496,14 @@ class SetupOrchestrator:
         return values
 
     @staticmethod
-    def _plist_env(path: pathlib.Path) -> Dict[str, str]:
+    def _plist_env(path: pathlib.Path, *, strict: bool = False) -> Dict[str, str]:
         try:
             payload = plistlib.loads(path.read_bytes())
             raw = payload.get("EnvironmentVariables", {})
+            if strict and isinstance(raw, dict) and any(
+                not isinstance(key, str) or not isinstance(value, str) for key, value in raw.items()
+            ):
+                raise ValueError("invalid plist environment value")
             return {str(key): str(value) for key, value in raw.items()} if isinstance(raw, dict) else {}
         except (OSError, plistlib.InvalidFileException, AttributeError):
             return {}
@@ -2087,6 +2107,28 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 pass
         if sigterm_handler is not None and signal.getsignal(signal.SIGTERM) is sigterm_handler:
             signal.signal(signal.SIGTERM, previous_sigterm)
+
+
+def member_artifact_path(member: str, home: pathlib.Path, system: str) -> pathlib.Path:
+    """Locate an installed member without constructing a setup orchestrator."""
+    if system == "Linux":
+        return home / ".config" / "caty-gateway" / (member + ".env")
+    if system == "Darwin":
+        return home / "Library" / "LaunchAgents" / ("ai.caty.gateway." + member + ".plist")
+    raise ValueError("unsupported platform")
+
+
+def read_member_env(path: pathlib.Path, system: str) -> Dict[str, str]:
+    """Read service values using the installer parsers, without running setup."""
+    if system == "Linux":
+        values = SetupOrchestrator._read_env_file(path, strict=True)
+    elif system == "Darwin":
+        values = SetupOrchestrator._plist_env(path, strict=True)
+    else:
+        raise ValueError("unsupported platform")
+    if any(not key or "=" in key or "\x00" in key or "\x00" in value for key, value in values.items()):
+        raise ValueError("invalid environment value")
+    return values
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -224,6 +224,7 @@ def test_qr_member_failure_is_safe_before_import(system, content, tmp_path, monk
     assert output.out == ''
     assert len(output.err.splitlines()) == 1
     assert 'shell-tok-1' not in output.err
+    assert 'fake-secret' not in output.err
     if system == 'Windows':
         assert output.err.strip() == (
             "ERROR: unsupported platform 'Windows'; "
@@ -235,11 +236,65 @@ def test_qr_member_failure_is_safe_before_import(system, content, tmp_path, monk
             if system == 'Linux'
             else 'Library/LaunchAgents/ai.caty.gateway.fake-member.plist'
         )
-        assert output.err.strip() == (
-            "ERROR: no installed environment for member 'fake-member' at "
-            f'{tmp_path / relative}; '
-            'run caty-gateway setup --member fake-member first'
-        )
+        if content is None:
+            assert output.err.strip() == (
+                "ERROR: no installed environment for member 'fake-member' at "
+                f'{tmp_path / relative}; '
+                'run caty-gateway setup --member fake-member first'
+            )
+        else:
+            assert output.err.strip() == (
+                "ERROR: invalid installed environment for member 'fake-member' at "
+                f'{tmp_path / relative} (unreadable, malformed, or missing CATY_TOKEN); '
+                'rerun caty-gateway setup --member fake-member'
+            )
+
+
+def test_qr_member_empty_home_does_not_read_cwd(tmp_path, monkeypatch, member_runtime, capsys):
+    monkeypatch.setenv('HOME', '')
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / 'home'
+    monkeypatch.setattr(cli.pathlib.Path, 'home', lambda: home)
+    path = tmp_path / '.config/caty-gateway/fake-member.env'
+    path.parent.mkdir(parents=True)
+    path.write_text('CATY_TOKEN=cwd-tok-1\n', encoding='utf-8')
+
+    assert cli.main(['qr', '--member', 'fake-member']) == 2
+    run, imports = member_runtime
+    run.assert_not_called()
+    assert imports == []
+    output = capsys.readouterr()
+    assert output.out == ''
+    assert output.err.splitlines() == [
+        "ERROR: no installed environment for member 'fake-member' at "
+        f"{home / '.config/caty-gateway/fake-member.env'}; "
+        'run caty-gateway setup --member fake-member first'
+    ]
+    assert 'cwd-tok-1' not in os.environ.values()
+
+
+def test_qr_member_rejects_invalid_identifier(member_runtime, capsys):
+    assert cli.main(['qr', '--member', '../x']) == 2
+    run, imports = member_runtime
+    run.assert_not_called()
+    assert imports == []
+    output = capsys.readouterr()
+    assert output.out == ''
+    assert len(output.err.splitlines()) == 1
+    assert 'invalid member identifier' in output.err
+
+
+def test_qr_member_flag_as_last_argument_exits_cleanly(member_runtime, capsys):
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(['qr', '--member'])
+    assert exit_info.value.code == 2
+    run, imports = member_runtime
+    run.assert_not_called()
+    assert imports == []
+    output = capsys.readouterr()
+    assert output.out == ''
+    assert 'expected one argument' in output.err
+    assert 'Traceback' not in output.err
 
 
 def test_legacy_qr_member_directs_to_public_cli(capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,9 @@
+import builtins
+import os
+import plistlib
 import subprocess
 import sys
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -7,11 +11,19 @@ import pytest
 from caty_gateway import cli
 
 
-def test_no_arguments_print_help(capsys):
+def test_help_lists_all_six_subcommands_with_descriptions(capsys):
     assert cli.main([]) == 0
     text = capsys.readouterr().out
     for command in ('setup', 'status', 'serve', 'qr', 'push', 'doctor'):
         assert command in text
+    normalized = ' '.join(text.split())
+    for description in (
+        'Install, start, verify, and pair one gateway member',
+        'Passive preflight for a backend, port, and public URL',
+        'Send a gateway event',
+        'Reissue the pairing QR (use --member to load the installed service environment)',
+    ):
+        assert description in normalized
 
 
 @pytest.mark.parametrize('command', ['setup', 'status', 'serve', 'qr', 'doctor'])
@@ -52,7 +64,7 @@ def test_qr_delegates_without_serve_guard(monkeypatch):
 def test_module_help_is_independent_of_backend_configuration(monkeypatch, tmp_path):
     monkeypatch.setenv('CATY_BACKEND', 'hermes')
     monkeypatch.delenv('CATY_HERMES_API_KEY', raising=False)
-    result = subprocess.run([sys.executable, '-m', 'caty_gateway', '--help'], cwd=tmp_path, capture_output=True, text=True)
+    result = subprocess.run([sys.executable, '-B', '-m', 'caty_gateway', '--help'], cwd=tmp_path, capture_output=True, text=True)
     assert result.returncode == 0
     assert 'doctor' in result.stdout
     assert 'Traceback' not in result.stderr
@@ -81,7 +93,7 @@ def test_legacy_module_serve_fails_closed_before_backend_config(arguments, monke
     monkeypatch.setenv('CATY_TOKEN', '')
     monkeypatch.setenv('CATY_BACKEND', 'hermes')
     monkeypatch.setenv('CATY_HERMES_API_KEY', '')
-    result = subprocess.run([sys.executable, '-m', 'caty_gateway.caty_gateway', *arguments], cwd=tmp_path, capture_output=True, text=True)
+    result = subprocess.run([sys.executable, '-B', '-m', 'caty_gateway.caty_gateway', *arguments], cwd=tmp_path, capture_output=True, text=True)
     assert result.returncode == 2
     assert len(result.stderr.splitlines()) == 1
     assert 'CATY_TOKEN must be non-empty' in result.stderr
@@ -98,3 +110,150 @@ def test_unknown_backend_has_release_error(command, capsys):
         "post-release: backend 'fake-backend' is not supported in this release; "
         "supported: claude, codex, openclaw, hermes, openai-compat"
     )
+
+
+@pytest.fixture
+def member_runtime(monkeypatch, tmp_path):
+    # Isolate every loaded variable and never read or write the real HOME.
+    monkeypatch.setattr(os, 'environ', dict(os.environ, HOME=str(tmp_path)))
+    monkeypatch.setattr(cli.platform, 'system', lambda: 'Linux')
+    run = mock.Mock(return_value=0)
+    imported_environments = []
+    original_import = builtins.__import__
+
+    def import_runtime(name, *args, **kwargs):
+        if name == 'caty_gateway.caty_gateway':
+            imported_environments.append(dict(os.environ))
+            return SimpleNamespace(main=run)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', import_runtime)
+    return run, imported_environments
+
+
+def test_qr_member_linux_loads_before_import_and_preserves_flags(tmp_path, member_runtime):
+    path = tmp_path / '.config/caty-gateway/fake-member.env'
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        '# Installed environment\n'
+        'CATY_TOKEN="inst-tok-1"\n'
+        "CATY_ID='fake-member'\n"
+        'CATY_GATEWAY_PORT=9876\n'
+        'CATY_PUBLIC_URL="https://example.invalid/member"\n'
+        'CATY_NAME="A \\"quoted\\" name"\n'
+        "CUSTOM_VALUE='literal $value'\n"
+        'PATH="/fake/service/bin"\n', encoding='utf-8',
+    )
+    os.environ.update(CATY_TOKEN='shell-tok-1', CATY_GATEWAY_PORT='1234')
+    shell_path = os.environ.get('PATH')
+    assert cli.main(['qr', '--qr-delivery', 'url', '--member', 'fake-member', '--wait-visible-seconds', '30']) == 0
+    run, imports = member_runtime
+    run.assert_called_once_with(['qr', '--qr-delivery', 'url', '--wait-visible-seconds', '30'])
+    assert len(imports) == 1
+    assert imports[0]['CATY_TOKEN'] == 'inst-tok-1'
+    assert imports[0]['CATY_GATEWAY_PORT'] == '9876'
+    assert imports[0]['CATY_ID'] == 'fake-member'
+    assert imports[0]['CATY_NAME'] == 'A "quoted" name'
+    assert imports[0]['CUSTOM_VALUE'] == 'literal $value'
+    assert imports[0]['CATY_PUBLIC_URL'] == 'https://example.invalid/member'
+    assert imports[0].get('PATH') == shell_path
+
+
+@pytest.mark.parametrize(('line', 'expected'), [
+    (br"CUSTOM_VALUE='literal\'" + b'\n', 'literal\\'),
+    (br'CUSTOM_VALUE="literal\\"' + b'\n', 'literal\\'),
+])
+def test_qr_member_linux_accepts_valid_terminal_backslashes(tmp_path, member_runtime, line, expected):
+    path = tmp_path / '.config/caty-gateway/fake-member.env'
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b'CATY_TOKEN=inst-tok-1\n' + line)
+
+    assert cli.main(['qr', '--member', 'fake-member']) == 0
+    run, imports = member_runtime
+    run.assert_called_once_with(['qr'])
+    assert imports[0]['CUSTOM_VALUE'] == expected
+
+
+@pytest.mark.parametrize('member_flags', [['--member=fake-member'], ['--mem', 'fake-member']])
+def test_qr_member_darwin_loads_plist(tmp_path, monkeypatch, member_runtime, member_flags):
+    monkeypatch.setattr(cli.platform, 'system', lambda: 'Darwin')
+    path = tmp_path / 'Library/LaunchAgents/ai.caty.gateway.fake-member.plist'
+    path.parent.mkdir(parents=True)
+    values = dict(CATY_TOKEN='plist-tok-1', CATY_ID='fake-member', CATY_GATEWAY_PORT='9876',
+                  CATY_PUBLIC_URL='https://example.invalid/member', CUSTOM_VALUE='A "quoted" value')
+    path.write_bytes(plistlib.dumps({'EnvironmentVariables': dict(values, PATH='/fake/service/bin')}))
+    os.environ.update(CATY_TOKEN='shell-tok-1', CATY_GATEWAY_PORT='1234')
+    shell_path = os.environ.get('PATH')
+    assert cli.main(['qr', *member_flags, '--qr-delivery', 'url']) == 0
+    run, imports = member_runtime
+    run.assert_called_once_with(['qr', '--qr-delivery', 'url'])
+    assert len(imports) == 1
+    assert all(imports[0][key] == value for key, value in values.items())
+    assert imports[0].get('PATH') == shell_path
+
+
+@pytest.mark.parametrize('system,content', [
+    ('Linux', None),
+    ('Darwin', None),
+    ('Linux', b'CATY_ID=fake-member\n'),
+    ('Linux', b'CATY_TOKEN="   "\n'),
+    ('Linux', b'CATY_TOKEN="fake-secret\n'),
+    ('Linux', br'CATY_TOKEN="fake-secret\"' + b'\n'),
+    ('Linux', b'CATY_TOKEN=fake-secret\ninvalid-line\n'),
+    ('Linux', b'CATY_TOKEN=fake-secret\x00\n'),
+    ('Linux', b'\xff'),
+    ('Darwin', b'not-a-plist-fake-secret'),
+    ('Darwin', b'<?xml version="1.0"?><plist><dict>'),
+    ('Darwin', plistlib.dumps({'EnvironmentVariables': {'CATY_ID': 'fake-member'}})),
+    ('Darwin', plistlib.dumps({'EnvironmentVariables': {'CATY_TOKEN': 123}})),
+    ('Windows', None),
+])
+def test_qr_member_failure_is_safe_before_import(system, content, tmp_path, monkeypatch, member_runtime, capsys):
+    monkeypatch.setattr(cli.platform, 'system', lambda: system)
+    if content is not None:
+        relative = '.config/caty-gateway/fake-member.env' if system == 'Linux' else 'Library/LaunchAgents/ai.caty.gateway.fake-member.plist'
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True)
+        path.write_bytes(content)
+    os.environ['CATY_TOKEN'] = 'shell-tok-1'
+    assert cli.main(['qr', '--member', 'fake-member']) == 2
+    run, imports = member_runtime
+    run.assert_not_called()
+    assert imports == []
+    output = capsys.readouterr()
+    assert output.out == ''
+    assert len(output.err.splitlines()) == 1
+    assert 'shell-tok-1' not in output.err
+    if system == 'Windows':
+        assert output.err.strip() == (
+            "ERROR: unsupported platform 'Windows'; "
+            'caty-gateway qr --member supports Linux and macOS'
+        )
+    else:
+        relative = (
+            '.config/caty-gateway/fake-member.env'
+            if system == 'Linux'
+            else 'Library/LaunchAgents/ai.caty.gateway.fake-member.plist'
+        )
+        assert output.err.strip() == (
+            "ERROR: no installed environment for member 'fake-member' at "
+            f'{tmp_path / relative}; '
+            'run caty-gateway setup --member fake-member first'
+        )
+
+
+def test_legacy_qr_member_directs_to_public_cli(capsys):
+    from caty_gateway.caty_gateway import _qr_cli_args
+    with pytest.raises(SystemExit) as exit_info:
+        _qr_cli_args(['--member', 'fake-member'])
+    assert exit_info.value.code == 2
+    assert capsys.readouterr().err.splitlines() == [
+        'ERROR: --member requires the public CLI: caty-gateway qr --member ID'
+    ]
+
+
+def test_setup_invalid_member_keeps_setup_error(tmp_path):
+    from caty_gateway.setup_orchestrator import SetupError, SetupOrchestrator
+
+    with pytest.raises(SetupError, match='--member must contain only'):
+        SetupOrchestrator(['--member', '..', '--plan-only'], env={'HOME': str(tmp_path)})


### PR DESCRIPTION
Lane for #6 (size S). Does not close #6 by keyword; the Issue is closed after MERGED is declared.

## What changed

- `caty-gateway qr --member <id>` reads the installed member environment (Linux `~/.config/caty-gateway/<id>.env`, macOS `~/Library/LaunchAgents/ai.caty.gateway.<id>.plist` → `EnvironmentVariables`) into `os.environ` **before** the gateway runtime is imported (its `PORT` / `CATY_TOKEN` / `CATY_ID` are module constants), then delegates to the existing qr path with `--member` stripped. Installed values override shell values except `PATH`. Missing artifact → `no installed environment …`; present but unreadable / malformed / no `CATY_TOKEN` → `invalid installed environment …`; both one stderr line, exit 2, no value echoed, runtime not imported. `HOME=""` never resolves relative to cwd.
- `setup_orchestrator`: `member_artifact_path()` / `read_member_env()` exposed; `_read_env_file` is a staticmethod with a strict mode used only by the qr path. Setup behaviour unchanged.
- Legacy programmatic `caty_gateway.main(['qr','--member',…])` fails closed with a pointer to the public CLI (the `python -m caty_gateway.caty_gateway` entry already routes through `cli.main`, so `--member` works there too).
- `caty-gateway --help` shows a one-line description for all 6 subcommands (setup / doctor were missing).
- docs: engineering.{md,ja.md} `#reissue-qr` simplified to the one-liner (anchor kept; README links untouched), reference.{md,ja.md} qr row updated, docs/env.md regenerated (line numbers + the `HOME` default expression).
- tests: env-file / plist fixtures under a fake HOME, override + PATH exclusion, import order, missing / malformed artifact, unsupported platform, argv stripping, empty HOME / cwd plant, invalid member id, trailing `--member`.

## Files touched (declared set = diff)

`src/caty_gateway/cli.py`, `src/caty_gateway/setup_orchestrator.py`, `src/caty_gateway/caty_gateway.py`, `tests/test_cli.py`, `docs/engineering.md`, `docs/engineering.ja.md`, `docs/reference.md`, `docs/reference.ja.md`, `docs/env.md`

`git diff --stat origin/main...88d96c2`: 9 files, +355 / −64 (tests 226 lines, docs/env.md regen 46 lines) → exceeds the 250-line pr-size gate; `size-exempt` requested from the owner (tests were added deliberately; nothing to split).

## 完了記録 (Completion record)

candidate SHA: 88d96c2（r1 候補 6c34423 → 席の MINOR 対応 delta を 88d96c2 として積んだ。L1-8: この記録が r1 記録を差し替える）
implementer: Codex (gpt-5.6 sol, `codex exec --profile sol --sandbox workspace-write`, 3-layer brief; delta も同じ席) — commit of the declared paths by Alpha (Claude Code / Fable 5.1)
reviewer: GLM 5.3 (r1 GO, delta GO) / Kimi K3 (r1 GO) / Opus 5 (r1 GO with 3 MINOR → delta: 2 fixed, 1 accepted as documented design, cumulative GO)
identity check: 別モデル（writer = Codex; seats = GLM / Kimi / Opus; Alpha did brief, integration and final inspection only and is not a vote）
CI: red — `test-lint / test-macos` only. All other checks green at 88d96c2 (`test-lint / test` 1145 passed + suite summary, `lint`, `gitleaks`, `history-check`, `risk-review-gate / detect-risk-paths`); `pr-size` red = size gate (owner `size-exempt`), `risk-review-gate` red = awaiting owner `risk-reviewed`. T-4 exception fields:
  failing check: `test-lint / test-macos` / run: https://github.com/caty-ai/caty-gateway/actions/runs/33983552525 @ 88d96c2 (rerun of the failed job: same failure) / 観測日付: 2026-09-06
  無関係の根拠: same single failure at r1 6c34423 (https://github.com/caty-ai/caty-gateway/actions/runs/33982420085): `tests/test_setup_process_e2e.py::test_pair_claim_survives_sigkill_and_consumed_tombstone_survives_process_restart — GatewayStartError: timed out waiting for gateway readiness (START_TIMEOUT_SECONDS = 8.0)`. That test spawns `serve` and never touches `--member`; the diff does not change the serve path. The same test passes on a macOS host with this tree (`make test` → `1145 passed, 252 subtests passed`, 2026-09-06). The macOS lane was activated by the public flip and has no run on `main` yet (first activation = this PR), so the red is the lane's baseline, not a regression.
  既知 Issue: #13（LC-1 退場トリガー = macOS lane green on main）
  owner 承認: https://github.com/caty-ai/caty-gateway/pull/10#issuecomment-5554030396 （shojikumaru, 2026-09-05T18:51Z: "T-4 exception approved … OK to merge"）+ `size-exempt` / `risk-reviewed` ラベル（同人・gate 緑）
release: v0.1.1（出荷相当: CLI の挙動と利用者向け手順が変わる。v0.1.0 は 2026-09-06 に Release 済みのため同梱不可 → merge 後に annotated tag `v0.1.1` + GitHub Release。オーナーが `deferred → #9`（PyPI 初回 publish に同梱）を選ぶ場合は L1-8 の差し替え記録で更新）
previous release: v0.1.0 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.0（履行済み・main `e4d1845`）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| `caty-gateway qr --member <id>` works from a fresh terminal on Linux and macOS (env file / plist fixture) | PASS | `tests/test_cli.py`: Linux env-file fixture and Darwin plist fixture under fake `HOME` with mocked runtime main; asserts the 4 keys at call time, `PATH` untouched, file value overrides shell value, delegated argv = `['qr','--qr-delivery','url']`. Opus seat re-verified import order in a real interpreter (`caty_gateway.caty_gateway` absent from `sys.modules` until after env load). Live on the macOS host: `HOME=<empty dir> python -B -m caty_gateway qr --member nope` → 1 stderr line, exit 2, no traceback (2026-09-06). Real installed service end-to-end on Linux/macOS: not measured in this lane (fixtures only) |
| `caty-gateway --help` shows a one-line description for all 6 subcommands | PASS | `python -B -m caty_gateway --help` → setup / status / serve / qr / push / doctor each with a description (2026-09-06); pinned by `test_no_arguments_print_help` + new help assertions |
| docs/engineering.{md,ja.md} "Reissuing the QR" simplified; docs/reference updated | PASS | `git diff origin/main...88d96c2 -- docs/`: Linux `set -a` recipe and macOS `plutil` loop replaced by `caty-gateway qr --member <id>`; `grep -c reissue-qr docs/engineering.md docs/engineering.ja.md` = 1 / 1; README*.md not in diff (2026-09-06) |
| tests / lint green | PASS (local + ubuntu CI) / see CI field for macOS | local `make test` (venv, rebased on `e4d1845`): `1145 passed, 252 subtests passed`, `suites: declared=53 executed=53 skipped=0`, scrub-audit 0 findings, env-inventory 122 names no drift, publication gate OK; `make lint` PASS; CI `test-lint / test` + `lint` green at 88d96c2 (2026-09-06) |

### Review (3 seats, fresh context, blind, read-only; fixed checks F1–F5 all PASS on every seat)

- **GLM 5.3** — r1 GO (NOTEs: `next(tail)` sentinel, legacy-entry message wording, non-semantic port validation, pre-existing `--wait-visible-seconds` float/int asymmetry). Delta 88d96c2: cumulative GO, both notes fixed.
- **Kimi K3** — r1 GO (NOTEs: abbreviation coupling with argparse is deliberate, error wording, no cli-level invalid-id test, same pre-existing float/int asymmetry). Invalid-id test added in the delta.
- **Opus 5** — r1 GO with 3 MINOR: empty `HOME` → relative path (fixed + test), one message for four causes (fixed), PATH-only deny-list (accepted as documented design: the artifact is the service's own 0600 file; withdrawn). Delta: cumulative GO; remaining NOTEs non-blocking (fixture uses a dict for `os.environ`; helpers placed below `main()`; READMEs still describe the manual route → follow-up candidate).
- Pre-existing, out of scope (2 seats): `--wait-visible-seconds` is `float` in cli.py but `int` in the runtime parser.

Seat outputs are kept in the session scratchpad; the summary above is the record.

### Owner actions needed before merge

1. `size-exempt` label (diff 419 lines vs 250 gate; tests + generated env.md).
2. `risk-reviewed` label (gate flags `setup_orchestrator.py` / `caty_gateway.py` as auth-risk paths).
3. macOS lane: either a T-4 exception comment on this PR referencing #13, or fix #13 first and re-run.
4. release: `v0.1.1` at merge (proposed) or `deferred → #9`.

### Not in this lane

public flip / tag / PyPI / README body (only the linked docs changed). T-2 regression-test default: size S but tests were added anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
