### PR TITLE
tests: raise the process-e2e readiness budget for hosted macOS and report the measured readiness (#13)

### DIFF
--- a/tests/test_setup_process_e2e.py
+++ b/tests/test_setup_process_e2e.py
@@ -7,13 +7,17 @@ import socket
 import subprocess
 import sys
 import time
+import warnings
 from pathlib import Path
 
 
 GATEWAY_COMMAND = [sys.executable, "-m", "caty_gateway.caty_gateway"]
 TEST_AGENT = "pairing-process-e2e"
 TEST_TOKEN = "process-e2e-" + "token-1128"
-START_TIMEOUT_SECONDS = 8.0
+# #13: hosted macOS runners stall in HTTPServer.server_bind -> socket.getfqdn before
+# listen(); the old 8 s budget only covered local hosts and the ubuntu runner.
+START_TIMEOUT_SECONDS = 60.0
+READINESS_WARN_SECONDS = 2.0
 
 
 class GatewayStartError(AssertionError):
@@ -87,6 +91,7 @@ def _terminate_and_capture(process):
 
 
 def _spawn_and_wait_ready(env, port):
+    started_at = time.monotonic()
     process = subprocess.Popen(
         GATEWAY_COMMAND,
         env=env,
@@ -96,7 +101,9 @@ def _spawn_and_wait_ready(env, port):
     )
     ready = False
     try:
-        deadline = time.monotonic() + START_TIMEOUT_SECONDS
+        deadline = started_at + START_TIMEOUT_SECONDS
+        probes = 0
+        first_observation = "no response"
         last_observation = "no response"
         while time.monotonic() < deadline:
             if process.poll() is not None:
@@ -106,29 +113,48 @@ def _spawn_and_wait_ready(env, port):
                     f"rc={process.returncode} stdout={stdout!r} stderr={stderr!r}",
                     stderr,
                 )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            probes += 1
             try:
                 status, payload = _request(
                     port,
                     "GET",
                     "/health",
                     headers={"Authorization": f"Bearer {TEST_TOKEN}"},
-                    timeout=0.25,
+                    timeout=min(1.0, remaining),
                 )
                 last_observation = f"status={status} payload={payload!r}"
+                if probes == 1:
+                    first_observation = last_observation
                 if (
                     process.poll() is None
                     and status == 200
                     and payload == {"ok": True, "agent": TEST_AGENT}
                 ):
+                    elapsed = time.monotonic() - started_at
+                    if elapsed > READINESS_WARN_SECONDS:
+                        warnings.warn(
+                            f"gateway readiness took {elapsed:.2f}s on {sys.platform} "
+                            f"(budget {START_TIMEOUT_SECONDS:.0f}s, {probes} probes)",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
                     ready = True
                     return process
             except (OSError, http.client.HTTPException, ValueError) as error:
                 last_observation = repr(error)
+                if probes == 1:
+                    first_observation = last_observation
             time.sleep(0.05)
 
+        elapsed = time.monotonic() - started_at
         stdout, stderr = _terminate_and_capture(process)
         raise GatewayStartError(
-            "timed out waiting for gateway readiness: "
+            "timed out waiting for gateway readiness after "
+            f"{elapsed:.2f}s (budget {START_TIMEOUT_SECONDS:.0f}s, {probes} probes, "
+            f"platform {sys.platform}): first={first_observation}; "
             f"last={last_observation}; stdout={stdout!r}; stderr={stderr!r}",
             stderr,
         )


### PR DESCRIPTION
Lane for #13 (size S, test-only). Does not close #13 by keyword; the Issue is closed after the lane is green on `main` (Done-when 3).

## What changed

- `tests/test_setup_process_e2e.py` only. `START_TIMEOUT_SECONDS` 8.0 → 60.0; the per-probe `/health` timeout 0.25 s → 1.0 s, capped by the remaining budget (never ≤ 0).
- The readiness timeout message now carries the measurement the Issue asks for: elapsed seconds, budget, probe count, `sys.platform`, and the first / last probe observation (plus the child's stdout / stderr as before). `GatewayStartError(message, stderr)` keeps its signature, so the `address_in_use` retry is untouched.
- On a slow-but-green start (elapsed > `READINESS_WARN_SECONDS = 2.0`) a `RuntimeWarning` with the measured readiness is emitted, so the pytest warnings summary on CI records the number even when the test passes.
- SIGKILL / tombstone assertions, `/pair/new` → `/pair/claim` → `409 pairing_consumed`, and the address-in-use retry logic are unchanged (no skip / xfail / platform guard / retry-around-assert).
- No new environment variable (would need `tools/env-inventory.py` classification); constant raised instead, as the Issue's default route.

Root cause (reading, to be confirmed by the measurement on this PR's macOS run): the child's stdout stops right after `相槌 … をロード` and never reaches the startup banner printed after `ThreadingHTTPServer((bind_host, PORT), Handler)` (`src/caty_gateway/caty_gateway.py:5849`). Python's `HTTPServer.server_bind` calls `socket.getfqdn(host)` after `bind()`, and reverse DNS stalls on hosted macOS runners; the probe's `TimeoutError` = SYN accepted into the backlog, nothing listening yet. A server-side follow-up (skip `getfqdn` in `server_bind`) is filed separately if the measured readiness confirms this; it is out of this lane's declared files.

## Files touched (declared set = diff)

`tests/test_setup_process_e2e.py`

`git diff --stat origin/main...8eaefce`: 1 file, +30 / −4 (under the 250-line pr-size gate; no `size-exempt` needed; no risk paths touched, no `risk-reviewed` needed).

## 完了記録 (Completion record)

candidate SHA: 8eaefce
implementer: Codex (gpt-5.6 sol, `codex exec --profile sol --sandbox workspace-write`, 3-layer brief). The Codex sandbox forbids loopback `bind()`, so the self-verification checks were run by Alpha (Claude Code / Fable 5.1) on the macOS host; commit of the declared path by Alpha.
reviewer: GLM 5.3 (GO, 1 NIT) / Opus 5 (GO, 2 MINOR + 2 NIT) / Kimi K3 (GO, 1 MINOR + 1 NIT); no delta round needed
identity check: 別モデル（writer = Codex; seats = GLM 5.3 / Opus 5 / Kimi K3 per `loom-seats --size S --absent codex-sol`, `same_family_seats: []` for writer codex-sol; Alpha did brief, integration and final inspection only and is not a vote）
CI: green at 8eaefce (2026-09-06): `test-lint / test-macos` PASS https://github.com/caty-ai/caty-gateway/actions/runs/33986521847/job/101360982859 (`1145 passed, 3 warnings, 252 subtests passed in 138.22s`, `suites: declared=53 executed=53 skipped=0`, publication gate OK), `test-lint / test` PASS, `test-lint / lint` PASS, `gitleaks`, `history-check`, `pr-size` (34 lines), `risk-review-gate` (no risk paths), `watch` all PASS; `test-macos-skip` skipped as designed (public repo).
release: N/A（②挙動・公開API・配布物を変えない — test-only change; no runtime code, CLI, docs or packaging touched）
previous release: v0.1.1 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.1（履行済み・main `2ae51ef`, PR #10）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| Root cause confirmed on the macOS runner (readiness time measured, e.g. elapsed time to first `/health` 200 in the failure message) | PASS | Failure message now measures: local proof with a child that never listens and a 0.6 s budget → `timed out waiting for gateway readiness after 0.65s (budget 1s, 12 probes, platform darwin): first=ConnectionRefusedError(61, 'Connection refused'); last=ConnectionRefusedError(61, 'Connection refused'); stdout=''; stderr=''` (2026-09-06). Success-path measurement: with `READINESS_WARN_SECONDS = 0.0` the real gateway emitted `gateway readiness took 0.11s on darwin (budget 60s, 3 probes)` (2026-09-06). macOS-runner measurement (this PR's `test-lint / test-macos`, 2026-09-06): the warnings summary shows three starts at `gateway readiness took 36.29s on darwin (budget 60s, 37 probes)` / `36.23s (38 probes)` / `36.47s (39 probes)`, a deterministic ~36 s per start, consistent with the `HTTPServer.server_bind` → `socket.getfqdn` stall (the banner is only printed after the constructor returns). Root cause confirmed; the server-side fix is tracked in #19. |
| `tests/test_setup_process_e2e.py` readiness budget adjusted for CI without weakening the sigkill / tombstone assertions | PASS | `git diff 2ae51ef..8eaefce`: constants 8.0→60.0 and 0.25→`min(1.0, remaining)`; `_sigkill_and_wait` and the test body's asserts are not in the diff. Single test ×3 on the macOS host: `1 passed in 0.42s / 0.95s / 0.35s` (2026-09-06). Full suite `make test PYTHON=<venv>` → `1145 passed, 252 subtests passed in 40.91s`, `suites: declared=53 executed=53 skipped=0`, scrub-audit 0 findings, env-inventory 122 names no drift, publication gate OK (2026-09-06). |
| `test-lint / test-macos` green on `main` (first green run URL recorded here) | N/A for this PR — verified after merge | Recorded on #13 after the first `main` run; this PR's own macOS check is the pre-merge proxy (see CI field). |
| PR #10 re-run green on the macOS lane after the fix lands (or owner T-4 exception recorded on PR #10) | N/A — already satisfied by the second branch | Owner T-4 exception on PR #10: https://github.com/caty-ai/caty-gateway/pull/10#issuecomment-5554030396 (shojikumaru, 2026-09-05T18:51Z); #10 is MERGED as `2ae51ef`. |

### Review (3 seats, fresh context, blind, read-only; fixed checks F1–F5)

- **GLM 5.3** — GO. NIT: `stacklevel=2` attributes the warning to `_start_gateway` rather than the test, and it can fire up to 3× per test (one per start); cosmetic, measurement text intact. Accepted as is (the three per-start numbers are exactly the measurement wanted).
- **Opus 5** — GO. MINOR 1: the success-path `RuntimeWarning` would become a failure if `filterwarnings = error` / `-W error` were ever adopted (latent: repo has no pytest config; forced `-W error::RuntimeWarning` → 1 failed). Accepted as documented design: the warning is the deliberate measurement channel and the repo has no warnings-as-errors policy; if one is added, the emitter moves to stderr in that lane. MINOR 2: worst-case wall clock now ~180 s realistic (3 × 60 s), theoretical ~900 s through the address-in-use retries; `test-lint.yml` has no `timeout-minutes` and relies on the 360 min job default. Accepted: bounded, and a red macOS run now costs minutes instead of seconds; #19 removes the stall itself. NIT: per-socket timeout may overshoot the deadline by 2–3 s; `first_observation` is redundant with `last_observation` when `probes == 1`. Opus also saw one unrelated flaky failure in `tests/test_avatar_engine.py` (`shutil.rmtree` `Directory not empty` while three seats ran the suite concurrently on the same host; passes in isolation, green on both CI lanes, file untouched).
- **Kimi K3** — GO. MINOR: no measurement is logged when a green start takes ≤ 2 s (accepted: Done-when 1 asks for the failure-message measurement, which is unconditional). NIT: the final probe may get an arbitrarily small positive timeout; the resulting exception is caught and only updates `last_observation`.
- Fixed checks F1–F5: PASS on all three seats. Seat outputs are kept in the session scratchpad; the summary above is the record.

### Owner actions needed before merge

1. Confirm `test-lint / test-macos` is green on this PR (the Done-when 3 proxy). No `size-exempt` (34 lines) and no `risk-reviewed` (no risk path) needed.

### Not in this lane

Server-side `getfqdn` avoidance (separate follow-up Issue), `.github/workflows/**`, pyproject / PyPI (#9), docs, tag / release. T-2 regression-test default: size S → exempt; the change is itself test code, and the new failure-message / warning paths were exercised by throwaway snippets on the host (output above), not by added tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
