### PR TITLE
docs: README x4 link caty.talk, one-command install first, absolute URLs for PyPI; pyproject 0.1.2 (#11)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-[🇺🇸 English](README.md) ｜ **🇯🇵 日本語** ｜ [🇨🇳 简体中文](README.zh.md) ｜ [🇹🇭 ไทย](README.th.md)
+[🇺🇸 English](https://github.com/caty-ai/caty-gateway/blob/main/README.md) ｜ [**🇯🇵 日本語**](https://github.com/caty-ai/caty-gateway/blob/main/README.ja.md) ｜ [🇨🇳 简体中文](https://github.com/caty-ai/caty-gateway/blob/main/README.zh.md) ｜ [🇹🇭 ไทย](https://github.com/caty-ai/caty-gateway/blob/main/README.th.md)
 
-![caty-gateway の hero 画像。左に iPhone（CatyPhone）、右にパソコンの中で動く AI。2 つを結ぶ 1 本の線の途中に小さな門（gateway）があり、線は閉じた私設ネットワークの中だけを通っている。](assets/readme/hero.png)
+![caty-gateway の hero 画像。左に iPhone（CatyPhone）、右にパソコンの中で動く AI。2 つを結ぶ 1 本の線の途中に小さな門（gateway）があり、線は閉じた私設ネットワークの中だけを通っている。](https://raw.githubusercontent.com/caty-ai/caty-gateway/main/assets/readme/hero.png)
 
 <h4>あなたのパソコンで動いている AI と、iPhone アプリ CatyPhone から声で話せるようにする、小さな常駐プログラムです。</h4>
 
 [![CI](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml/badge.svg?event=pull_request)](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE)
 ![python](https://img.shields.io/badge/python-3.10%2B-lightgrey?logo=python&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
-![PyPI](https://img.shields.io/badge/PyPI-not%20yet-lightgrey)
+[![PyPI](https://img.shields.io/pypi/v/caty-gateway)](https://pypi.org/project/caty-gateway/)
 
 [できること](#what) ｜ [必要なもの](#requirements) ｜ [使いはじめる](#start) ｜ [安心の理由](#safety) ｜ [困ったとき](#troubleshooting) ｜ [もっと詳しく](#more)
 
@@ -21,7 +21,7 @@
 
 **いつもの AI を、ポケットに連れて出る。**
 
-🔧 [エンジニア向けドキュメント](docs/engineering.md) ｜ 📘 [詳細仕様](docs/reference.md)
+🔧 [エンジニア向けドキュメント](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) ｜ 📘 [詳細仕様](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md)
 
 </div>
 
@@ -39,7 +39,7 @@
 共通する原因はシンプルで、**パソコンの AI に、スマホから届く入口がない**ことです。
 caty-gateway は、その入口だけを引き受けます。
 
-なお caty-gateway は、**パソコンで AI エージェントかローカル LLM を動かしている人**のためのツールです。iPhone アプリ CatyPhone と組で使います。パソコン側に AI がない場合や、CatyPhone を使わない場合は対象外になります。
+なお caty-gateway は、**パソコンで AI エージェントかローカル LLM を動かしている人**のためのツールです。iPhone アプリ [CatyPhone](https://caty.talk) と組で使います。パソコン側に AI がない場合や、CatyPhone を使わない場合は対象外になります。
 
 ---
 
@@ -149,6 +149,14 @@ https://github.com/caty-ai/caty-gateway を読んで、caty-gateway を入れて
 
 **1. 入れる**
 
+ワンコマンドのインストーラーは、`uv` が無ければ用意してから caty-gateway を入れます。**PyPI 公開と同時に提供予定**（coming with the PyPI release）で、それまでは下の `uv` のコマンドを使ってください。
+
+```sh
+curl -fsSL https://caty.talk/gateway/install.sh | sh
+```
+
+`uv` がすでにある場合:
+
 ```sh
 uv tool install caty-gateway
 ```
@@ -191,7 +199,7 @@ caty-gateway setup --member me --backend claude
 
 **4. QR を読む**
 
-CatyPhone を開き、表示された QR コードを読み取ります。iPhone とパソコンがつながり、話しかけられるようになります。QR は 10 分で期限が切れ、一度読むと使えなくなります。もう一度出すには `caty-gateway qr --member <id>` を実行します（手順は [QR の再発行](docs/engineering.md#reissue-qr)）。
+CatyPhone を開き、表示された QR コードを読み取ります。iPhone とパソコンがつながり、話しかけられるようになります。QR は 10 分で期限が切れ、一度読むと使えなくなります。もう一度出すには `caty-gateway qr --member <id>` を実行します（手順は [QR の再発行](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr)）。
 
 <details>
 <summary>つまずいたとき（command not found・uv や pipx が無い・Python が古い）</summary>
@@ -234,12 +242,12 @@ caty-gateway は「入口」だけを担当し、AI にも会話にも余計な�
 
   会話の記録は `~/.local/state/caty-gateway/history/<名前>/` に置かれ、フォルダを消せば消えます
 
-gateway が会話を送る先は、あなたが選んだ AI だけです。それ以外に外部へ送られるものは、音声の読み上げやアバター生成などの**任意機能を自分で有効にしたときだけ**です。どの機能が何を送るかは [プライバシー](docs/privacy.md) に書いてあります。
+gateway が会話を送る先は、あなたが選んだ AI だけです。それ以外に外部へ送られるものは、音声の読み上げやアバター生成などの**任意機能を自分で有効にしたときだけ**です。どの機能が何を送るかは [プライバシー](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md) に書いてあります。
 
 <details>
 <summary>やめたいとき（丸ごと消す手順）</summary>
 
-1. 常駐サービスを止めて外す（macOS は `~/Library/LaunchAgents/ai.caty.gateway.<名前>.plist`、Linux は `caty-gateway-<名前>.service`）。手順は [エンジニア向けドキュメント](docs/engineering.md#uninstall) にあります
+1. 常駐サービスを止めて外す（macOS は `~/Library/LaunchAgents/ai.caty.gateway.<名前>.plist`、Linux は `caty-gateway-<名前>.service`）。手順は [エンジニア向けドキュメント](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#uninstall) にあります
 2. 設定と記録のフォルダを消す: `~/.config/caty-gateway/`、`~/.local/state/caty-gateway/`、`~/.local/share/caty-gateway/`
 3. 本体を消す: `uv tool uninstall caty-gateway`（pipx なら `pipx uninstall caty-gateway`）
 
@@ -281,14 +289,14 @@ gateway が AI 側に作ったものはありません。会話は AI 自身の�
 <details>
 <summary>起動はしたのに、QR を読んでもつながらない</summary>
 
-iPhone がパソコンと同じ Tailscale ネットワークにいないことがほとんどです。iPhone の Tailscale アプリで同じアカウントにログインし、接続がオンになっていることを確認して、[QR の再発行](docs/engineering.md#reissue-qr) の手順で新しい QR を出し直します。Tailscale 以外の経路（家の Wi-Fi の IP など）では、起動はできてもペアリングで止まります。
+iPhone がパソコンと同じ Tailscale ネットワークにいないことがほとんどです。iPhone の Tailscale アプリで同じアカウントにログインし、接続がオンになっていることを確認して、[QR の再発行](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr) の手順で新しい QR を出し直します。Tailscale 以外の経路（家の Wi-Fi の IP など）では、起動はできてもペアリングで止まります。
 
 </details>
 
 <details>
 <summary>QR を読んだら「期限切れ」と出た</summary>
 
-QR は表示から 10 分で切れます。[QR の再発行](docs/engineering.md#reissue-qr) の手順で出し直してください。
+QR は表示から 10 分で切れます。[QR の再発行](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr) の手順で出し直してください。
 
 </details>
 
@@ -304,11 +312,11 @@ QR は表示から 10 分で切れます。[QR の再発行](docs/engineering.md
 
 | 知りたいこと | ページ |
 |---|---|
-| 仕組み・コマンド一覧・サービスの運用・アンインストール | [エンジニア向けドキュメント](docs/engineering.md) |
-| 全コマンドの引数・保存先・ペアリングの決まりごと | [詳細仕様](docs/reference.md) |
-| 環境変数の全表（自動生成） | [docs/env.md](docs/env.md) |
-| どの機能が何を外部に送るか | [docs/privacy.md](docs/privacy.md) |
-| ペアリングの通信仕様 | [docs/contracts/pairing-v1.md](docs/contracts/pairing-v1.md) |
+| 仕組み・コマンド一覧・サービスの運用・アンインストール | [エンジニア向けドキュメント](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) |
+| 全コマンドの引数・保存先・ペアリングの決まりごと | [詳細仕様](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md) |
+| 環境変数の全表（自動生成） | [docs/env.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/env.md) |
+| どの機能が何を外部に送るか | [docs/privacy.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md) |
+| ペアリングの通信仕様 | [docs/contracts/pairing-v1.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/contracts/pairing-v1.md) |
 
 backend の追加や修正は、次の手順で歓迎します。
 
@@ -320,7 +328,7 @@ backend の追加や修正は、次の手順で歓迎します。
 
 自分の使っている AI を足すには、プリセットを 1 つ書き足すだけで始められます。
 
-手順・テストの型・レビューの流れは [CONTRIBUTING.md](CONTRIBUTING.md) にあります。不具合や質問は [Issue](https://github.com/caty-ai/caty-gateway/issues) へどうぞ。
+手順・テストの型・レビューの流れは [CONTRIBUTING.md](https://github.com/caty-ai/caty-gateway/blob/main/CONTRIBUTING.md) にあります。不具合や質問は [Issue](https://github.com/caty-ai/caty-gateway/issues) へどうぞ。
 
 ---
 
@@ -328,7 +336,7 @@ backend の追加や修正は、次の手順で歓迎します。
 
 ## ライセンス
 
-[MIT License](LICENSE) です。自分の AI に自分で入口を付けられるように、誰でも自由に使って組み込めるライセンスを選びました。
+[MIT License](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE) です。自分の AI に自分で入口を付けられるように、誰でも自由に使って組み込めるライセンスを選びました。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-**🇺🇸 English** ｜ [🇯🇵 日本語](README.ja.md) ｜ [🇨🇳 简体中文](README.zh.md) ｜ [🇹🇭 ไทย](README.th.md)
+[**🇺🇸 English**](https://github.com/caty-ai/caty-gateway/blob/main/README.md) ｜ [🇯🇵 日本語](https://github.com/caty-ai/caty-gateway/blob/main/README.ja.md) ｜ [🇨🇳 简体中文](https://github.com/caty-ai/caty-gateway/blob/main/README.zh.md) ｜ [🇹🇭 ไทย](https://github.com/caty-ai/caty-gateway/blob/main/README.th.md)
 
-![caty-gateway hero image. An iPhone (CatyPhone) on the left, and an AI running inside a computer on the right. A single line connects the two, with a small gate (gateway) partway along it, and the line only travels inside a closed private network.](assets/readme/hero.png)
+![caty-gateway hero image. An iPhone (CatyPhone) on the left, and an AI running inside a computer on the right. A single line connects the two, with a small gate (gateway) partway along it, and the line only travels inside a closed private network.](https://raw.githubusercontent.com/caty-ai/caty-gateway/main/assets/readme/hero.png)
 
 <h4>A small background program that lets you talk by voice, from the CatyPhone iPhone app, to the AI running on your computer.</h4>
 
 [![CI](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml/badge.svg?event=pull_request)](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE)
 ![python](https://img.shields.io/badge/python-3.10%2B-lightgrey?logo=python&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
-![PyPI](https://img.shields.io/badge/PyPI-not%20yet-lightgrey)
+[![PyPI](https://img.shields.io/pypi/v/caty-gateway)](https://pypi.org/project/caty-gateway/)
 
 [What it does](#what) ｜ [What you need](#requirements) ｜ [Getting started](#start) ｜ [Why it is safe](#safety) ｜ [When something goes wrong](#troubleshooting) ｜ [Learn more](#more)
 
@@ -21,7 +21,7 @@ ask it to keep going, or show it a photo or your screen. Conversations go to the
 
 **Take your usual AI with you, in your pocket.**
 
-🔧 [Engineering docs](docs/engineering.md) ｜ 📘 [Reference](docs/reference.md)
+🔧 [Engineering docs](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) ｜ 📘 [Reference](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md)
 
 </div>
 
@@ -39,7 +39,7 @@ If even one of these rings a bell, caty-gateway is for you.
 The common cause is simple: **your computer's AI has no way for your phone to reach it.**
 caty-gateway takes care of exactly that, and nothing more.
 
-Note that caty-gateway is a tool for **people already running an AI agent or a local LLM on their computer**. It's meant to be used together with the CatyPhone iPhone app. If you don't have an AI running on your computer, or don't use CatyPhone, this isn't for you.
+Note that caty-gateway is a tool for **people already running an AI agent or a local LLM on their computer**. It's meant to be used together with the [CatyPhone](https://caty.talk) iPhone app. If you don't have an AI running on your computer, or don't use CatyPhone, this isn't for you.
 
 ---
 
@@ -149,6 +149,14 @@ The commands are spelled out on purpose, so the agent doesn't have to guess how 
 
 **1. Install**
 
+The one-command installer sets up `uv` if it's missing, then installs caty-gateway. It is **coming with the PyPI release**; until then, use the `uv` command below it.
+
+```sh
+curl -fsSL https://caty.talk/gateway/install.sh | sh
+```
+
+If you already have `uv`:
+
 ```sh
 uv tool install caty-gateway
 ```
@@ -191,7 +199,7 @@ Replace `me` with a short name for yourself using letters and numbers (or just k
 
 **4. Scan the QR code**
 
-Open CatyPhone and scan the QR code shown on screen. Your iPhone and computer will connect, and you'll be able to start talking. The QR code expires after 10 minutes, and can only be scanned once. To get a new one, run `caty-gateway qr --member <id>` (see [Reissuing the QR](docs/engineering.md#reissue-qr)).
+Open CatyPhone and scan the QR code shown on screen. Your iPhone and computer will connect, and you'll be able to start talking. The QR code expires after 10 minutes, and can only be scanned once. To get a new one, run `caty-gateway qr --member <id>` (see [Reissuing the QR](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr)).
 
 <details>
 <summary>If something goes wrong (command not found, no uv or pipx, Python too old)</summary>
@@ -234,12 +242,12 @@ caty-gateway only handles the "front door" — it doesn't do anything extra to y
 
   conversation history is stored at `~/.local/state/caty-gateway/history/<name>/`, and deleting that folder deletes it
 
-The gateway sends the conversation only to the AI you chose. Beyond that, nothing goes out except for **optional features you turn on yourself**, such as text-to-speech or avatar generation. Which features send what is documented in [privacy](docs/privacy.md).
+The gateway sends the conversation only to the AI you chose. Beyond that, nothing goes out except for **optional features you turn on yourself**, such as text-to-speech or avatar generation. Which features send what is documented in [privacy](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md).
 
 <details>
 <summary>If you want to stop using it (full removal steps)</summary>
 
-1. Stop and remove the background service (macOS: `~/Library/LaunchAgents/ai.caty.gateway.<name>.plist`; Linux: `caty-gateway-<name>.service`). Full steps are in the [Engineering docs](docs/engineering.md#uninstall)
+1. Stop and remove the background service (macOS: `~/Library/LaunchAgents/ai.caty.gateway.<name>.plist`; Linux: `caty-gateway-<name>.service`). Full steps are in the [Engineering docs](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#uninstall)
 2. Delete the config and history folders: `~/.config/caty-gateway/`, `~/.local/state/caty-gateway/`, `~/.local/share/caty-gateway/`
 3. Remove the program itself: `uv tool uninstall caty-gateway` (or `pipx uninstall caty-gateway`)
 
@@ -281,14 +289,14 @@ That AI's CLI either isn't installed or you aren't logged in. `WARN claude crede
 <details>
 <summary>It started, but scanning the QR code doesn't connect</summary>
 
-In most cases, your iPhone isn't on the same Tailscale network as your computer. Log in to the same Tailscale account on your iPhone's Tailscale app, confirm the connection is on, and generate a fresh QR code by following [Reissuing the QR](docs/engineering.md#reissue-qr). Any route other than Tailscale (like your home Wi-Fi's IP address) may start up fine but will get stuck at pairing.
+In most cases, your iPhone isn't on the same Tailscale network as your computer. Log in to the same Tailscale account on your iPhone's Tailscale app, confirm the connection is on, and generate a fresh QR code by following [Reissuing the QR](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr). Any route other than Tailscale (like your home Wi-Fi's IP address) may start up fine but will get stuck at pairing.
 
 </details>
 
 <details>
 <summary>Scanning the QR code says it "expired"</summary>
 
-QR codes expire 10 minutes after they're shown. Follow [Reissuing the QR](docs/engineering.md#reissue-qr) to get a new one.
+QR codes expire 10 minutes after they're shown. Follow [Reissuing the QR](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr) to get a new one.
 
 </details>
 
@@ -304,11 +312,11 @@ Documentation is split by what you're looking for. The engineering guide and the
 
 | What you want to know | Page |
 |---|---|
-| How it works, all commands, running the service, uninstalling | [Engineering docs](docs/engineering.md) |
-| Every command's arguments, where files are saved, pairing rules | [Reference](docs/reference.md) |
-| Full table of environment variables (auto-generated) | [docs/env.md](docs/env.md) |
-| What each feature sends externally | [docs/privacy.md](docs/privacy.md) |
-| Pairing protocol details | [docs/contracts/pairing-v1.md](docs/contracts/pairing-v1.md) |
+| How it works, all commands, running the service, uninstalling | [Engineering docs](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) |
+| Every command's arguments, where files are saved, pairing rules | [Reference](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md) |
+| Full table of environment variables (auto-generated) | [docs/env.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/env.md) |
+| What each feature sends externally | [docs/privacy.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md) |
+| Pairing protocol details | [docs/contracts/pairing-v1.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/contracts/pairing-v1.md) |
 
 Adding or fixing a backend is welcome — here's how.
 
@@ -320,7 +328,7 @@ Adding or fixing a backend is welcome — here's how.
 
 Adding support for the AI you use can be as simple as writing one preset.
 
-Setup steps, test conventions, and the review process are in [CONTRIBUTING.md](CONTRIBUTING.md). For bugs or questions, please open an [issue](https://github.com/caty-ai/caty-gateway/issues).
+Setup steps, test conventions, and the review process are in [CONTRIBUTING.md](https://github.com/caty-ai/caty-gateway/blob/main/CONTRIBUTING.md). For bugs or questions, please open an [issue](https://github.com/caty-ai/caty-gateway/issues).
 
 ---
 
@@ -328,7 +336,7 @@ Setup steps, test conventions, and the review process are in [CONTRIBUTING.md](C
 
 ## License
 
-[MIT License](LICENSE). We chose a license that lets anyone freely use and build with this, so you can add a front door to your own AI too.
+[MIT License](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE). We chose a license that lets anyone freely use and build with this, so you can add a front door to your own AI too.
 
 ---
 

--- a/README.th.md
+++ b/README.th.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-[🇺🇸 English](README.md) ｜ [🇯🇵 日本語](README.ja.md) ｜ [🇨🇳 简体中文](README.zh.md) ｜ **🇹🇭 ไทย**
+[🇺🇸 English](https://github.com/caty-ai/caty-gateway/blob/main/README.md) ｜ [🇯🇵 日本語](https://github.com/caty-ai/caty-gateway/blob/main/README.ja.md) ｜ [🇨🇳 简体中文](https://github.com/caty-ai/caty-gateway/blob/main/README.zh.md) ｜ [**🇹🇭 ไทย**](https://github.com/caty-ai/caty-gateway/blob/main/README.th.md)
 
-![ภาพ hero ของ caty-gateway ทางซ้ายคือ iPhone (CatyPhone) ทางขวาคือ AI ที่ทำงานอยู่ในคอมพิวเตอร์ มีเส้นหนึ่งเส้นเชื่อมทั้งสองเข้าด้วยกัน ตรงกลางเส้นมีประตูเล็ก ๆ (gateway) และเส้นนี้วิ่งอยู่ภายในเครือข่ายส่วนตัวที่ปิดเท่านั้น](assets/readme/hero.png)
+![ภาพ hero ของ caty-gateway ทางซ้ายคือ iPhone (CatyPhone) ทางขวาคือ AI ที่ทำงานอยู่ในคอมพิวเตอร์ มีเส้นหนึ่งเส้นเชื่อมทั้งสองเข้าด้วยกัน ตรงกลางเส้นมีประตูเล็ก ๆ (gateway) และเส้นนี้วิ่งอยู่ภายในเครือข่ายส่วนตัวที่ปิดเท่านั้น](https://raw.githubusercontent.com/caty-ai/caty-gateway/main/assets/readme/hero.png)
 
 <h4>โปรแกรมขนาดเล็กที่ทำงานอยู่เบื้องหลัง ช่วยให้คุณพูดคุยด้วยเสียงกับ AI ที่ทำงานอยู่บนคอมพิวเตอร์ของคุณ ผ่านแอป iPhone ชื่อ CatyPhone</h4>
 
 [![CI](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml/badge.svg?event=pull_request)](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE)
 ![python](https://img.shields.io/badge/python-3.10%2B-lightgrey?logo=python&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
-![PyPI](https://img.shields.io/badge/PyPI-not%20yet-lightgrey)
+[![PyPI](https://img.shields.io/pypi/v/caty-gateway)](https://pypi.org/project/caty-gateway/)
 
 [ทำอะไรได้บ้าง](#what) ｜ [สิ่งที่ต้องมี](#requirements) ｜ [เริ่มใช้งาน](#start) ｜ [เหตุผลที่วางใจได้](#safety) ｜ [เมื่อมีปัญหา](#troubleshooting) ｜ [รายละเอียดเพิ่มเติม](#more)
 
@@ -21,7 +21,7 @@
 
 **พา AI ที่คุ้นเคย ติดกระเป๋าออกไปด้วย**
 
-🔧 [เอกสารสำหรับวิศวกร](docs/engineering.md) ｜ 📘 [ข้อกำหนดโดยละเอียด](docs/reference.md)
+🔧 [เอกสารสำหรับวิศวกร](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) ｜ 📘 [ข้อกำหนดโดยละเอียด](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md)
 
 </div>
 
@@ -39,7 +39,7 @@
 สาเหตุร่วมนั้นเรียบง่ายมาก คือ **AI บนคอมพิวเตอร์ไม่มีทางเข้าจากสมาร์ตโฟน**
 caty-gateway รับหน้าที่เป็นทางเข้านั้นเพียงอย่างเดียว
 
-caty-gateway เป็นเครื่องมือสำหรับ **ผู้ที่รัน AI agent หรือ local LLM อยู่บนคอมพิวเตอร์** และใช้งานคู่กับแอป iPhone ชื่อ CatyPhone หากคอมพิวเตอร์ของคุณไม่มี AI หรือไม่ได้ใช้ CatyPhone เครื่องมือนี้จะไม่เหมาะกับคุณ
+caty-gateway เป็นเครื่องมือสำหรับ **ผู้ที่รัน AI agent หรือ local LLM อยู่บนคอมพิวเตอร์** และใช้งานคู่กับแอป iPhone ชื่อ [CatyPhone](https://caty.talk) หากคอมพิวเตอร์ของคุณไม่มี AI หรือไม่ได้ใช้ CatyPhone เครื่องมือนี้จะไม่เหมาะกับคุณ
 
 ---
 
@@ -149,6 +149,14 @@ Tailscale คือแอปฟรีที่สร้างเครือข�
 
 **1. ติดตั้ง**
 
+ตัวติดตั้งแบบคำสั่งเดียวจะติดตั้ง `uv` ให้ก่อนถ้ายังไม่มี แล้วจึงติดตั้ง caty-gateway **จะพร้อมใช้งานพร้อมกับการเผยแพร่บน PyPI** (coming with the PyPI release) ระหว่างนี้ให้ใช้คำสั่ง `uv` ด้านล่างแทน
+
+```sh
+curl -fsSL https://caty.talk/gateway/install.sh | sh
+```
+
+ถ้ามี `uv` อยู่แล้ว:
+
 ```sh
 uv tool install caty-gateway
 ```
@@ -191,7 +199,7 @@ caty-gateway setup --member me --backend claude
 
 **4. สแกน QR**
 
-เปิด CatyPhone แล้วสแกนรหัส QR ที่แสดงขึ้นมา iPhone กับคอมพิวเตอร์จะเชื่อมต่อกัน และคุณจะพูดคุยกันได้ QR จะหมดอายุใน 10 นาที และเมื่อสแกนใช้แล้วครั้งหนึ่งจะใช้ซ้ำไม่ได้ หากต้องการแสดง QR ใหม่อีกครั้ง ให้รัน `caty-gateway qr --member <id>` (ดูขั้นตอนที่ [การออก QR ใหม่](docs/engineering.md#reissue-qr))
+เปิด CatyPhone แล้วสแกนรหัส QR ที่แสดงขึ้นมา iPhone กับคอมพิวเตอร์จะเชื่อมต่อกัน และคุณจะพูดคุยกันได้ QR จะหมดอายุใน 10 นาที และเมื่อสแกนใช้แล้วครั้งหนึ่งจะใช้ซ้ำไม่ได้ หากต้องการแสดง QR ใหม่อีกครั้ง ให้รัน `caty-gateway qr --member <id>` (ดูขั้นตอนที่ [การออก QR ใหม่](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr))
 
 <details>
 <summary>เมื่อติดขัด (command not found / ไม่มี uv หรือ pipx / Python เก่าเกินไป)</summary>
@@ -234,12 +242,12 @@ caty-gateway ทำหน้าที่เป็นเพียง "ทาง�
 
   ประวัติการสนทนาถูกเก็บไว้ที่ `~/.local/state/caty-gateway/history/<ชื่อ>/` ลบโฟลเดอร์นี้ก็ลบข้อมูลได้
 
-gateway ส่งบทสนทนาไปยัง AI ที่คุณเลือกเท่านั้น นอกเหนือจากนั้น สิ่งที่ถูกส่งออกไปภายนอกมีเฉพาะกรณีที่คุณ **เปิดใช้งานฟีเจอร์เสริมด้วยตัวเอง** เช่น การอ่านออกเสียงหรือการสร้างอวาตาร์เท่านั้น รายละเอียดว่าฟีเจอร์ใดส่งอะไรออกไป ดูได้ที่ [ความเป็นส่วนตัว](docs/privacy.md)
+gateway ส่งบทสนทนาไปยัง AI ที่คุณเลือกเท่านั้น นอกเหนือจากนั้น สิ่งที่ถูกส่งออกไปภายนอกมีเฉพาะกรณีที่คุณ **เปิดใช้งานฟีเจอร์เสริมด้วยตัวเอง** เช่น การอ่านออกเสียงหรือการสร้างอวาตาร์เท่านั้น รายละเอียดว่าฟีเจอร์ใดส่งอะไรออกไป ดูได้ที่ [ความเป็นส่วนตัว](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md)
 
 <details>
 <summary>เมื่อต้องการเลิกใช้งาน (ขั้นตอนลบทั้งหมด)</summary>
 
-1. หยุดและถอนบริการเบื้องหลัง (macOS คือ `~/Library/LaunchAgents/ai.caty.gateway.<ชื่อ>.plist`, Linux คือ `caty-gateway-<ชื่อ>.service`) ขั้นตอนละเอียดดูที่ [เอกสารสำหรับวิศวกร](docs/engineering.md#uninstall)
+1. หยุดและถอนบริการเบื้องหลัง (macOS คือ `~/Library/LaunchAgents/ai.caty.gateway.<ชื่อ>.plist`, Linux คือ `caty-gateway-<ชื่อ>.service`) ขั้นตอนละเอียดดูที่ [เอกสารสำหรับวิศวกร](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#uninstall)
 2. ลบโฟลเดอร์การตั้งค่าและบันทึก: `~/.config/caty-gateway/`, `~/.local/state/caty-gateway/`, `~/.local/share/caty-gateway/`
 3. ลบตัวโปรแกรม: `uv tool uninstall caty-gateway` (ถ้าใช้ pipx ก็ `pipx uninstall caty-gateway`)
 
@@ -281,14 +289,14 @@ gateway ไม่ได้สร้างอะไรไว้ที่ฝั่
 <details>
 <summary>เริ่มระบบสำเร็จแล้ว แต่สแกน QR แล้วเชื่อมต่อไม่ได้</summary>
 
-ส่วนใหญ่เกิดจาก iPhone ไม่ได้อยู่ในเครือข่าย Tailscale เดียวกันกับคอมพิวเตอร์ ให้ล็อกอินแอป Tailscale บน iPhone ด้วยบัญชีเดียวกัน ตรวจสอบว่าการเชื่อมต่อเปิดอยู่ แล้วออก QR ใหม่ตามขั้นตอนที่ [การออก QR ใหม่](docs/engineering.md#reissue-qr) เส้นทางอื่นที่ไม่ใช่ Tailscale (เช่น IP ของ Wi-Fi ที่บ้าน) อาจเริ่มระบบได้ แต่จะติดขัดที่ขั้นตอนจับคู่ (pairing)
+ส่วนใหญ่เกิดจาก iPhone ไม่ได้อยู่ในเครือข่าย Tailscale เดียวกันกับคอมพิวเตอร์ ให้ล็อกอินแอป Tailscale บน iPhone ด้วยบัญชีเดียวกัน ตรวจสอบว่าการเชื่อมต่อเปิดอยู่ แล้วออก QR ใหม่ตามขั้นตอนที่ [การออก QR ใหม่](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr) เส้นทางอื่นที่ไม่ใช่ Tailscale (เช่น IP ของ Wi-Fi ที่บ้าน) อาจเริ่มระบบได้ แต่จะติดขัดที่ขั้นตอนจับคู่ (pairing)
 
 </details>
 
 <details>
 <summary>สแกน QR แล้วขึ้นว่า "หมดอายุ"</summary>
 
-QR จะหมดอายุภายใน 10 นาทีหลังแสดงผล กรุณาออกรหัสใหม่ตามขั้นตอนที่ [การออก QR ใหม่](docs/engineering.md#reissue-qr)
+QR จะหมดอายุภายใน 10 นาทีหลังแสดงผล กรุณาออกรหัสใหม่ตามขั้นตอนที่ [การออก QR ใหม่](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr)
 
 </details>
 
@@ -304,11 +312,11 @@ QR จะหมดอายุภายใน 10 นาทีหลังแส�
 
 | สิ่งที่อยากรู้ | หน้าเอกสาร |
 |---|---|
-| กลไกการทำงาน รายการคำสั่งทั้งหมด การดูแลบริการ การถอนการติดตั้ง | [เอกสารสำหรับวิศวกร](docs/engineering.md) |
-| อาร์กิวเมนต์ของทุกคำสั่ง / ตำแหน่งจัดเก็บ / กติกาการจับคู่ (pairing) | [ข้อกำหนดโดยละเอียด](docs/reference.md) |
-| ตารางตัวแปรสภาพแวดล้อมทั้งหมด (สร้างอัตโนมัติ) | [docs/env.md](docs/env.md) |
-| ฟีเจอร์ใดส่งข้อมูลอะไรออกไปภายนอก | [docs/privacy.md](docs/privacy.md) |
-| ข้อกำหนดการสื่อสารของการจับคู่ (pairing) | [docs/contracts/pairing-v1.md](docs/contracts/pairing-v1.md) |
+| กลไกการทำงาน รายการคำสั่งทั้งหมด การดูแลบริการ การถอนการติดตั้ง | [เอกสารสำหรับวิศวกร](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) |
+| อาร์กิวเมนต์ของทุกคำสั่ง / ตำแหน่งจัดเก็บ / กติกาการจับคู่ (pairing) | [ข้อกำหนดโดยละเอียด](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md) |
+| ตารางตัวแปรสภาพแวดล้อมทั้งหมด (สร้างอัตโนมัติ) | [docs/env.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/env.md) |
+| ฟีเจอร์ใดส่งข้อมูลอะไรออกไปภายนอก | [docs/privacy.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md) |
+| ข้อกำหนดการสื่อสารของการจับคู่ (pairing) | [docs/contracts/pairing-v1.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/contracts/pairing-v1.md) |
 
 การเพิ่มหรือแก้ไข backend สามารถทำได้ตามขั้นตอนต่อไปนี้ ยินดีต้อนรับ
 
@@ -320,7 +328,7 @@ QR จะหมดอายุภายใน 10 นาทีหลังแส�
 
 หากต้องการเพิ่ม AI ที่คุณใช้อยู่ ให้เริ่มต้นได้เพียงเขียน preset เพิ่มขึ้นมา 1 ตัว
 
-ขั้นตอน / รูปแบบการทดสอบ / กระบวนการรีวิว ดูได้ที่ [CONTRIBUTING.md](CONTRIBUTING.md) หากพบปัญหาหรือมีคำถาม แจ้งได้ที่ [Issue](https://github.com/caty-ai/caty-gateway/issues)
+ขั้นตอน / รูปแบบการทดสอบ / กระบวนการรีวิว ดูได้ที่ [CONTRIBUTING.md](https://github.com/caty-ai/caty-gateway/blob/main/CONTRIBUTING.md) หากพบปัญหาหรือมีคำถาม แจ้งได้ที่ [Issue](https://github.com/caty-ai/caty-gateway/issues)
 
 ---
 
@@ -328,7 +336,7 @@ QR จะหมดอายุภายใน 10 นาทีหลังแส�
 
 ## สัญญาอนุญาต
 
-เป็น [MIT License](LICENSE) เราเลือกสัญญาอนุญาตนี้เพื่อให้ทุกคนสามารถใช้และนำไปประกอบเข้ากับ AI ของตนเองได้อย่างอิสระ เพื่อสร้างทางเข้าให้ AI ของตัวเองได้ด้วยตัวเอง
+เป็น [MIT License](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE) เราเลือกสัญญาอนุญาตนี้เพื่อให้ทุกคนสามารถใช้และนำไปประกอบเข้ากับ AI ของตนเองได้อย่างอิสระ เพื่อสร้างทางเข้าให้ AI ของตัวเองได้ด้วยตัวเอง
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-[🇺🇸 English](README.md) ｜ [🇯🇵 日本語](README.ja.md) ｜ **🇨🇳 简体中文** ｜ [🇹🇭 ไทย](README.th.md)
+[🇺🇸 English](https://github.com/caty-ai/caty-gateway/blob/main/README.md) ｜ [🇯🇵 日本語](https://github.com/caty-ai/caty-gateway/blob/main/README.ja.md) ｜ [**🇨🇳 简体中文**](https://github.com/caty-ai/caty-gateway/blob/main/README.zh.md) ｜ [🇹🇭 ไทย](https://github.com/caty-ai/caty-gateway/blob/main/README.th.md)
 
-![caty-gateway 的 hero 图。左边是 iPhone（CatyPhone），右边是在电脑里运行的 AI。连接两者的一条线中间有一个小小的门（gateway），这条线只经过一个封闭的私有网络。](assets/readme/hero.png)
+![caty-gateway 的 hero 图。左边是 iPhone（CatyPhone），右边是在电脑里运行的 AI。连接两者的一条线中间有一个小小的门（gateway），这条线只经过一个封闭的私有网络。](https://raw.githubusercontent.com/caty-ai/caty-gateway/main/assets/readme/hero.png)
 
 <h4>一个小巧的常驻程序，让你可以从 iPhone 应用 CatyPhone 用语音，和你电脑上正在运行的 AI 对话。</h4>
 
 [![CI](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml/badge.svg?event=pull_request)](https://github.com/caty-ai/caty-gateway/actions/workflows/test-lint.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE)
 ![python](https://img.shields.io/badge/python-3.10%2B-lightgrey?logo=python&logoColor=white)
 ![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
-![PyPI](https://img.shields.io/badge/PyPI-not%20yet-lightgrey)
+[![PyPI](https://img.shields.io/pypi/v/caty-gateway)](https://pypi.org/project/caty-gateway/)
 
 [能做什么](#what) ｜ [需要准备什么](#requirements) ｜ [开始使用](#start) ｜ [为什么放心](#safety) ｜ [遇到问题](#troubleshooting) ｜ [了解更多](#more)
 
@@ -21,7 +21,7 @@
 
 **把平时用的 AI，装进口袋随身带走。**
 
-🔧 [面向工程师的文档](docs/engineering.md) ｜ 📘 [详细规格](docs/reference.md)
+🔧 [面向工程师的文档](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) ｜ 📘 [详细规格](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md)
 
 </div>
 
@@ -39,7 +39,7 @@
 原因很简单：**电脑上的 AI，没有一个能从手机进入的入口**。
 caty-gateway 只负责补上这个入口。
 
-需要说明的是，caty-gateway 是为**在电脑上运行 AI 代理或本地 LLM 的人**准备的工具，需要搭配 iPhone 应用 CatyPhone 一起使用。如果电脑上没有 AI，或者不使用 CatyPhone，就不适用本工具。
+需要说明的是，caty-gateway 是为**在电脑上运行 AI 代理或本地 LLM 的人**准备的工具，需要搭配 iPhone 应用 [CatyPhone](https://caty.talk) 一起使用。如果电脑上没有 AI，或者不使用 CatyPhone，就不适用本工具。
 
 ---
 
@@ -149,6 +149,14 @@ Tailscale 是一款免费应用，用来搭建只连接你自己设备之间的�
 
 **1. 安装**
 
+一键安装脚本会在没有 `uv` 时先安装 `uv`，再安装 caty-gateway。它将**随 PyPI 发布一起提供**（coming with the PyPI release）；在那之前，请使用下面的 `uv` 命令。
+
+```sh
+curl -fsSL https://caty.talk/gateway/install.sh | sh
+```
+
+如果已经有 `uv`：
+
 ```sh
 uv tool install caty-gateway
 ```
@@ -191,7 +199,7 @@ caty-gateway setup --member me --backend claude
 
 **4. 扫描二维码**
 
-打开 CatyPhone，扫描显示出来的二维码。这样 iPhone 和电脑就连接上了，可以开始用语音对话。二维码 10 分钟后会失效，扫过一次也就不能再用。想重新显示，请执行 `caty-gateway qr --member <id>`（步骤见 [重新生成二维码](docs/engineering.md#reissue-qr)）。
+打开 CatyPhone，扫描显示出来的二维码。这样 iPhone 和电脑就连接上了，可以开始用语音对话。二维码 10 分钟后会失效，扫过一次也就不能再用。想重新显示，请执行 `caty-gateway qr --member <id>`（步骤见 [重新生成二维码](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr)）。
 
 <details>
 <summary>遇到问题时（提示 command not found、没有 uv 或 pipx、Python 版本太旧）</summary>
@@ -234,12 +242,12 @@ caty-gateway 只负责「入口」这一件事，不会对 AI 或对话做任何
 
   对话记录存放在 `~/.local/state/caty-gateway/history/<名字>/`，删除该文件夹即可清除
 
-gateway 只会把对话发送给你选定的 AI。除此之外，只有在你**自己主动开启语音朗读、头像生成等可选功能时**才会有内容发送到外部。哪些功能会发送什么内容，写在[隐私说明](docs/privacy.md)里。
+gateway 只会把对话发送给你选定的 AI。除此之外，只有在你**自己主动开启语音朗读、头像生成等可选功能时**才会有内容发送到外部。哪些功能会发送什么内容，写在[隐私说明](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md)里。
 
 <details>
 <summary>想要卸载时（彻底删除的步骤）</summary>
 
-1. 停止并移除常驻服务（macOS 是 `~/Library/LaunchAgents/ai.caty.gateway.<名字>.plist`，Linux 是 `caty-gateway-<名字>.service`）。具体步骤见[面向工程师的文档](docs/engineering.md#uninstall)
+1. 停止并移除常驻服务（macOS 是 `~/Library/LaunchAgents/ai.caty.gateway.<名字>.plist`，Linux 是 `caty-gateway-<名字>.service`）。具体步骤见[面向工程师的文档](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#uninstall)
 2. 删除配置和记录文件夹：`~/.config/caty-gateway/`、`~/.local/state/caty-gateway/`、`~/.local/share/caty-gateway/`
 3. 卸载本体：`uv tool uninstall caty-gateway`（使用 pipx 的话是 `pipx uninstall caty-gateway`）
 
@@ -281,14 +289,14 @@ gateway 不会在 AI 那一侧创建任何东西。对话会作为该 AI 自己�
 <details>
 <summary>已经启动了，但扫描二维码也连接不上</summary>
 
-多数情况是 iPhone 和电脑不在同一个 Tailscale 网络中。在 iPhone 的 Tailscale 应用里登录同一个账号，确认连接已开启，然后按 [重新生成二维码](docs/engineering.md#reissue-qr) 的步骤重新显示二维码。如果走的是 Tailscale 以外的路径（比如家中 Wi-Fi 的 IP），即使能启动，也会在配对阶段卡住。
+多数情况是 iPhone 和电脑不在同一个 Tailscale 网络中。在 iPhone 的 Tailscale 应用里登录同一个账号，确认连接已开启，然后按 [重新生成二维码](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr) 的步骤重新显示二维码。如果走的是 Tailscale 以外的路径（比如家中 Wi-Fi 的 IP），即使能启动，也会在配对阶段卡住。
 
 </details>
 
 <details>
 <summary>扫描二维码后提示「已过期」</summary>
 
-二维码从显示起 10 分钟后就会失效。请按 [重新生成二维码](docs/engineering.md#reissue-qr) 的步骤重新生成。
+二维码从显示起 10 分钟后就会失效。请按 [重新生成二维码](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md#reissue-qr) 的步骤重新生成。
 
 </details>
 
@@ -304,11 +312,11 @@ gateway 不会在 AI 那一侧创建任何东西。对话会作为该 AI 自己�
 
 | 想了解的内容 | 页面 |
 |---|---|
-| 工作机制、命令一览、服务运维、卸载方法 | [面向工程师的文档](docs/engineering.md) |
-| 全部命令的参数、保存位置、配对规则 | [详细规格](docs/reference.md) |
-| 环境变量完整表（自动生成） | [docs/env.md](docs/env.md) |
-| 哪些功能会向外部发送什么内容 | [docs/privacy.md](docs/privacy.md) |
-| 配对通信规格 | [docs/contracts/pairing-v1.md](docs/contracts/pairing-v1.md) |
+| 工作机制、命令一览、服务运维、卸载方法 | [面向工程师的文档](https://github.com/caty-ai/caty-gateway/blob/main/docs/engineering.md) |
+| 全部命令的参数、保存位置、配对规则 | [详细规格](https://github.com/caty-ai/caty-gateway/blob/main/docs/reference.md) |
+| 环境变量完整表（自动生成） | [docs/env.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/env.md) |
+| 哪些功能会向外部发送什么内容 | [docs/privacy.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/privacy.md) |
+| 配对通信规格 | [docs/contracts/pairing-v1.md](https://github.com/caty-ai/caty-gateway/blob/main/docs/contracts/pairing-v1.md) |
 
 欢迎按照以下步骤添加或修改 backend。
 
@@ -320,7 +328,7 @@ gateway 不会在 AI 那一侧创建任何东西。对话会作为该 AI 自己�
 
 要加入自己正在使用的 AI，只需添加一个预设配置即可开始。
 
-具体步骤、测试规范、审核流程，见 [CONTRIBUTING.md](CONTRIBUTING.md)。有 bug 或疑问，请前往 [Issue](https://github.com/caty-ai/caty-gateway/issues)。
+具体步骤、测试规范、审核流程，见 [CONTRIBUTING.md](https://github.com/caty-ai/caty-gateway/blob/main/CONTRIBUTING.md)。有 bug 或疑问，请前往 [Issue](https://github.com/caty-ai/caty-gateway/issues)。
 
 ---
 
@@ -328,7 +336,7 @@ gateway 不会在 AI 那一侧创建任何东西。对话会作为该 AI 自己�
 
 ## 许可协议
 
-采用 [MIT License](LICENSE)。为了让每个人都能自由使用并集成，自己为自己的 AI 装上入口，我们选择了这一许可协议。
+采用 [MIT License](https://github.com/caty-ai/caty-gateway/blob/main/LICENSE)。为了让每个人都能自由使用并集成，自己为自己的 AI 装上入口，我们选择了这一许可协议。
 
 ---
 

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -11,6 +11,7 @@ caty-gateway は、CatyPhone（iOS クライアント）と、ホスト上で動
 前提は `ffmpeg` / `ffprobe`・Tailscale ログイン済み・使う backend の CLI かサーバーの 3 つです。
 
 ```sh
+curl -fsSL https://caty.talk/gateway/install.sh | sh   # ワンコマンド導入（PyPI 公開と同時に提供予定）
 uv tool install caty-gateway            # または pipx install caty-gateway
 caty-gateway doctor --backend claude    # 受動チェックのみ。全 PASS まで直す
 caty-gateway setup --member me --backend claude --plan-only   # 実行予定を確認（何も書かない）

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -11,6 +11,7 @@ caty-gateway is an HTTP gateway that sits between CatyPhone (the iOS client) and
 The prerequisites are just three things: `ffmpeg` / `ffprobe`, an already logged-in Tailscale, and the CLI or server for the backend you plan to use.
 
 ```sh
+curl -fsSL https://caty.talk/gateway/install.sh | sh   # one-command install (coming with the PyPI release)
 uv tool install caty-gateway            # or: pipx install caty-gateway
 caty-gateway doctor --backend claude    # passive checks only. Fix until everything is PASS
 caty-gateway setup --member me --backend claude --plan-only   # preview the planned actions (writes nothing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caty-gateway"
-version = "0.1.0"
+version = "0.1.2"
 description = "A self-hosted voice and pairing gateway for Caty clients"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Lane for #11 (size S, docs + package version bump). Does not close #11 by keyword; the Issue is closed after MERGED is declared with the v0.1.2 tag + Release.

## What changed

- **Product page link.** In all four READMEs the "for people already running an AI … together with the CatyPhone iPhone app" line (line 42 in every language) links `CatyPhone` to https://caty.talk. Same sentence, same position in en / ja / zh / th.
- **Install section order.** "1. Install" now leads with the one-command installer `curl -fsSL https://caty.talk/gateway/install.sh | sh`, explicitly marked **coming with the PyPI release** (the URL is a 404 today; the paragraph says to use the `uv` command until then — no dead command presented as live, T-7). Then `uv tool install caty-gateway` (works after #9), then the existing `pipx` line. The GitHub `git+https` path stays in the troubleshooting `<details>` unchanged. `docs/engineering.md` / `docs/engineering.ja.md` Quick Start mirror the same order with one added line each.
- **PyPI precondition (PR #15 seats, comment on #11).** README.md is rendered on PyPI from the wheel and cannot be edited after release, so every relative link and the hero image in the four READMEs are absolute (`https://github.com/caty-ai/caty-gateway/blob/main/...`; hero via `raw.githubusercontent.com/.../main/assets/readme/hero.png`, 200 checked), and the static `PyPI: not yet` badge is now the live `img.shields.io/pypi/v/caty-gateway` badge linking to the PyPI project page. **Known and disclosed:** until #9 publishes, that live badge renders red "package or version not found" (shields JSON checked 2026-09-06). It is a machine-painted badge, not a static one (T-7 colour rule applies to static badges only); the owner may prefer to hold merge until the publish is imminent.
- **Language nav.** `inspect_readme.py langs` requires identical link-target sets across the four files and only exempts *relative* sibling-README links from that set. With absolute URLs, each README therefore links all four languages (its own language bold + linked). Structural check stays green.
- **`pyproject.toml`** `version = "0.1.0"` → `"0.1.2"` so tag `v0.1.2` and the package agree (#9 comment 2026-09-05T19:22Z). Nothing else in the file moved.

## Files touched (declared set = diff)

`README.md`, `README.ja.md`, `README.zh.md`, `README.th.md`, `docs/engineering.md`, `docs/engineering.ja.md`, `pyproject.toml`

`git diff --stat origin/main...67cd1e7` (main = `7806959`): 7 files, +107 / −73 (under the 250-line pr-size gate). `pyproject.toml` is on the `risk_paths_gates` list → `risk-reviewed` is required from the owner (see "Owner actions").

## 完了記録 (Completion record)

candidate SHA: 67cd1e7
implementer: Alpha (Claude Code / Fable 5.1) — direct edit, docs lane (README / docs / version string are on the direct-edit list); no Codex involvement
reviewer: Kimi K3 (GO-WITH-MINORS, 3 non-blocking minors) / Grok 4.6 (GO, 3 minors marked "do not block") / Gemini 3.8 Flash (GO, no findings; diff-only static seat — headless `agy` denied file reads and shell, so F1 is "NOT VERIFIABLE" for that seat and its vote counts as a read vote; on-disk F1 was verified by Kimi and Grok)
identity check: 別モデル（writer = Fable 5.1; seats per `loom-seats --size S --absent opus-5 --absent glm-5.3` = Grok 4.6 (substitute for GLM 5.3) / Kimi K3 / Gemini 3.8 Flash, `same_family_seats: []`; Opus not used because it shares the writer's family; GLM 5.3 was absent with a 429 weekly/monthly quota exhaustion, reset 2026-09-10 — recorded in the run ledger）
CI: at 67cd1e7 (2026-09-06): `test-lint / test` PASS (1m40s) https://github.com/caty-ai/caty-gateway/actions/runs/34009503920/job/101422718906 · `test-lint / test-macos` PASS (2m40s) https://github.com/caty-ai/caty-gateway/actions/runs/34009503920/job/101422718785 · `test-lint / lint`, `gitleaks`, `history-check`, `pr-size`, `watch`, `risk-review-gate / detect-risk-paths` all PASS; `test-macos-skip` / `strip-size-exempt` skipped as designed. `risk-review-gate / risk-review-gate` is **red by design** (https://github.com/caty-ai/caty-gateway/actions/runs/34009503822/job/101422739543): `pyproject.toml` is on `risk_paths_gates`, so the job fails closed until an owner applies `risk-reviewed` to this head — it is not a test failure and no T-4 exception is claimed; it turns green on the labeled re-run.
release: v0.1.2（出荷相当: 配布物 = package version 0.1.2 + PyPI-rendered README; annotated tag `v0.1.2` on the squash commit + GitHub Release after merge; #9 publishes from this tag）
previous release: v0.1.1 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.1（履行済み・Latest on Releases, checked 2026-09-06; PR #10 lane）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| README ×4: the opening "for CatyPhone users" line links https://caty.talk, same position in all four; `inspect_readme.py langs` still passes | PASS | `grep -n 'CatyPhone\](https://caty.talk)' README*.md` → exactly line 42 in each of the 4 files (2026-09-06). `python3 -B inspect_readme.py langs README.md README.ja.md README.zh.md README.th.md` → `PASS langs README.md`. `curl -I https://caty.talk` → 200. |
| Install section order: (1) `curl -fsSL https://caty.talk/gateway/install.sh \| sh` (2) `uv tool install caty-gateway` (3) wheel/git path stays in troubleshooting | PASS | In each README the "1. Install" block is: installer paragraph + fenced `curl … \| sh` → "If you already have `uv`:" + fenced `uv tool install caty-gateway` → `pipx` line; the `git+https://github.com/caty-ai/caty-gateway` line remains at the troubleshooting `<details>` (line 210 in each file), unchanged in the diff (2026-09-06). `docs/engineering*.md` Quick Start: same order, 1 added line each. |
| Until #9 ships, the installer line is marked "coming with the PyPI release" — no dead command in the quick start | PASS | The installer paragraph in en / ja / zh / th contains the literal `coming with the PyPI release` (ja / zh / th carry it in parentheses next to the translated phrase) and tells the reader to use the `uv` command until then. `curl -I https://caty.talk/gateway/install.sh` → 404 today, which is why the marking is in place (2026-09-06). |
| `make gate` green (no personal-account URLs; caty.talk is the product domain) | PASS | `make test PYTHON=<venv>` at 67cd1e7 (2026-09-06): `1149 passed, 252 subtests passed in 44.23s`, `suites: declared=54 executed=54 skipped=0`, `scrub-audit: 0 findings`, `env-inventory: 122 names, no drift`, `OK — publication gate passed with 0 explicit label whitelist entries.` (gate ran with `--account-slug shojikumaru --no-registry`; `personal URLs checked: 0`). |
| 3 seats, tag (target renamed to `v0.1.2` on 2026-09-05T19:22Z) | PASS (seats) / tag after merge | Seats: see Review below. Tag: `release: v0.1.2` declared above; cut on the squash commit after merge, then `gh release create` (or `gh release edit --notes-file` if release-sync created it first). |
| Absolute URLs for PyPI + live version badge (precondition added 2026-09-05T18:53Z) | PASS | `grep -o '\](\([^)h#][^)]*\)' README*.md \| grep -v '](http'` → no output in any of the 4 files (zero relative links / images). Hero → `https://raw.githubusercontent.com/caty-ai/caty-gateway/main/assets/readme/hero.png` (HTTP 200). Badge → `[![PyPI](https://img.shields.io/pypi/v/caty-gateway)](https://pypi.org/project/caty-gateway/)` in all 4 files (2026-09-06). |

### Review (3 seats, fresh context, blind, read-only; docs-only short delivery; F1–F5 fixed checks)

- **Kimi K3** — GO-WITH-MINORS. F1 PASS (every absolute-URL target exists at base `7806959` via `git cat-file -e`; anchors `reissue-qr` / `uninstall` at `docs/engineering.md:125,141`; `qr --member` at `src/caty_gateway/cli.py:21`; live: caty.talk 200, hero raw 200, blob URLs 200, install.sh 404 as designed), F2 N/A, F3 PASS (pyproject = one line), F4 PASS (ja/zh/th faithful; fences 14 each, `<details>` 7/7, tables intact; `langs` PASS), F5 PASS (declared set == diff; no `shojikumaru` URLs; 0 new `CATY_*`; static badges only blue/lightgrey). MINORs: (1) live PyPI badge renders red until #9 publishes — honest under T-7, optional revert to static `not yet` until release; (2) language-nav self-link — acceptable trade-off, no fix; (3) `docs/engineering*.md:14` Quick Start fence starts with the 404 `curl` line — optional: comment it out until the installer is live.
- **Grok 4.6** — GO. F1 PASS (same checks incl. in-tree existence of every `blob/main` / raw path; curl results identical), F2 N/A, F3 N/A, F4 PASS (fences 14/14, `<details>` 7/7, table rows 27/27, 12 corresponding headings, `langs` PASS), F5 PASS (7 declared files == `--name-status`; publication gate OK; `git+https` troubleshooting unchanged; worktree clean, no `__pycache__`). Same three items as Kimi, each marked "do not block": machine-red badge is not a fake green; self-link is required for `langs`; installer line in the docs fence is what #11 asked for and `curl -f` fail-closes so a 404 body is never piped to `sh` — no change required.
- **Gemini 3.8 Flash** (static, diff-only) — GO, no findings. F1 NOT VERIFIABLE (no tools), F2 N/A, F3 N/A, F4 PASS (semantic parity of the install note across ja/zh/th), F5 PASS (7 files, no personal URLs, no new env vars, no static green). Evidence: read of `git diff --stat` / `git diff 7806959..67cd1e7` only; nothing executed.
- **Alpha's disposition of the minors (writer, not a vote):** candidate kept at `67cd1e7`. The Quick Start `curl` line is explicitly requested by #11 ("install section leads with the one-command installer … marked coming with the PyPI release") and mirrors the README; `curl -fsSL` on a 404 exits non-zero without piping anything to `sh`. The red live badge is the disclosed cost of the PR #15 precondition (PyPI-rendered README cannot change after release). If the owner prefers, either can be flipped in a one-line follow-up before the tag — say so in the merge decision.
- GLM 5.3 was the roster's first seat but returned HTTP 429 (weekly/monthly limit exhausted, reset 2026-09-10 10:00); `loom-seats --size S --absent opus-5 --absent glm-5.3` → Grok 4.6 substitutes, Gemini 3.8 Flash fills the third seat (`same_family_seats: []`, `status: GO`). Recorded in the run ledger (`mc-log fail`).

- Seat outputs are kept in the session scratchpad; the summary above is the record.

### Owner actions needed before merge

1. **`risk-reviewed` label** — `pyproject.toml` is on the CI `risk_paths_gates` list, so `risk-review-gate` stays red until an owner on `.github/risk-reviewers.txt` applies the label to this head (`67cd1e7`). Apply it **after** the PR body is final (an edit or a new push voids the label). https://github.com/caty-ai/caty-gateway/pull/21
2. Merge decision (squash).

No `size-exempt` needed (107 + 73 < 250).

### After merge (Alpha)

Annotated tag `v0.1.2` on the squash commit → GitHub Release (title line ≤ 120 chars, notes point at this PR and the CI run) → MERGED comment with the tag URL on #11 → close #11 → note on #9: v0.1.2 Release exists; owner runs `gh workflow run publish.yml --repo caty-ai/caty-gateway -f version=0.1.2` after the pending-publisher registration.

### Not in this lane

`.github/workflows/**` (#9), running the PyPI publish (owner), Homebrew tap, MCP subcommand (#12), other README sections (#4), the installer script itself (LP side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
