### PR TITLE
server: bind without socket.getfqdn so startup is not blocked by slow reverse DNS (#19); pyproject 0.1.3

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -16,28 +16,28 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | name | default | tier | sensitivity | persistence | where |
 | --- | --- | --- | --- | --- | --- |
 | ANTHROPIC_API_KEY | None (unset) | C | secret | member env (0600) | src/caty_gateway/vision_describer.py:46 |
-| CATY_ACCENT_COLOR | '#FF8FB1'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:187; src/caty_gateway/setup_orchestrator.py:127 |
-| CATY_ADMIN_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:184 |
-| CATY_AGENT | 'main' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:130; src/caty_gateway/doctor.py:227; src/caty_gateway/setup_orchestrator.py:1159 |
-| CATY_ASSETS_VERSION | '1' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:188 |
-| CATY_ASSET_DIR | expression: str(resources.files('caty_gateway').joinpath('assets')) | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:189 |
+| CATY_ACCENT_COLOR | '#FF8FB1'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:188; src/caty_gateway/setup_orchestrator.py:127 |
+| CATY_ADMIN_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:185 |
+| CATY_AGENT | 'main' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:131; src/caty_gateway/doctor.py:227; src/caty_gateway/setup_orchestrator.py:1159 |
+| CATY_ASSETS_VERSION | '1' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:189 |
+| CATY_ASSET_DIR | expression: str(resources.files('caty_gateway').joinpath('assets')) | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:190 |
 | CATY_AVATAR_STYLE_REF | None (unset) | C | local | member env (0600) | src/caty_gateway/avatar_engine.py:525 |
 | CATY_AVATAR_VENDOR_HOST_ALLOWLIST | '' | C | public | member env (0600) | src/caty_gateway/caty_config.py:42 |
 | CATY_AVATAR_WORKDIR | None (unset) | C | local | member env (0600) | src/caty_gateway/avatar_engine.py:527 |
-| CATY_BACKEND | 'openclaw' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:131; src/caty_gateway/setup_orchestrator.py:122 |
+| CATY_BACKEND | 'openclaw' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:132; src/caty_gateway/setup_orchestrator.py:122 |
 | CATY_BACKEND_CONFIG_PATHS | '' | D | local | process-only | src/caty_gateway/setup_orchestrator.py:722 |
 | CATY_BACKEND_ENABLE_CMD | '' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1081 |
-| CATY_CLAUDE_BIN | 'claude' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:168; src/caty_gateway/doctor.py:216; src/caty_gateway/setup_orchestrator.py:692 |
-| CATY_CLAUDE_CWD | expression: os.path.expanduser('~'); expression: str(self.home) | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:170; src/caty_gateway/doctor.py:217 |
-| CATY_CLAUDE_MODEL | '' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:169 |
+| CATY_CLAUDE_BIN | 'claude' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:169; src/caty_gateway/doctor.py:216; src/caty_gateway/setup_orchestrator.py:692 |
+| CATY_CLAUDE_CWD | expression: os.path.expanduser('~'); expression: str(self.home) | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:171; src/caty_gateway/doctor.py:217 |
+| CATY_CLAUDE_MODEL | '' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:170 |
 | CATY_CLAUDE_PROJECTS_DIR | None (unset) | B | local | member env (0600) | src/caty_gateway/backends/claude.py:118 |
 | CATY_CONFIG_DIR | None (unset) | A | local | member env (0600) | src/caty_gateway/caty_config.py:112 |
-| CATY_EXTERNAL_PREVIEW | True | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1358 |
-| CATY_EXTERNAL_SEED_TURNS | '50' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1342 |
-| CATY_EXTERNAL_SESSIONS | False | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1350 |
-| CATY_FILLER_DIR | None (unset) | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:1863 |
-| CATY_GATEWAY_BIND | ''; '0.0.0.0' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:125; src/caty_gateway/cli.py:94 |
-| CATY_GATEWAY_PORT | '8788' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:128; src/caty_gateway/doctor.py:289; src/caty_gateway/setup_orchestrator.py:174 |
+| CATY_EXTERNAL_PREVIEW | True | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1359 |
+| CATY_EXTERNAL_SEED_TURNS | '50' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1343 |
+| CATY_EXTERNAL_SESSIONS | False | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1351 |
+| CATY_FILLER_DIR | None (unset) | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:1864 |
+| CATY_GATEWAY_BIND | ''; '0.0.0.0' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:126; src/caty_gateway/cli.py:94 |
+| CATY_GATEWAY_PORT | '8788' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:129; src/caty_gateway/doctor.py:289; src/caty_gateway/setup_orchestrator.py:174 |
 | CATY_GATEWAY_TOKEN | None (unset) | B | secret | member env (0600) | src/caty_gateway/backends/openclaw.py:138; src/caty_gateway/doctor.py:231 |
 | CATY_GATEWAY_URL | 'http://127.0.0.1:18789' | B | local | member env (0600) | src/caty_gateway/backends/openclaw.py:296; src/caty_gateway/doctor.py:241 |
 | CATY_GCLI_BIN | None (unset) | B | public | member env (0600) | src/caty_gateway/backends/generic_cli.py:83 |
@@ -48,24 +48,24 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_GCLI_PARSE_SPEC | None (unset) | B | public | member env (0600) | src/caty_gateway/backends/generic_cli.py:95 |
 | CATY_GCLI_RESUME_ARGS | None (unset) | B | public | member env (0600) | src/caty_gateway/backends/generic_cli.py:91 |
 | CATY_GCLI_SESSION_STORE | None (unset) | B | local | member env (0600) | src/caty_gateway/backends/generic_cli.py:99 |
-| CATY_HERMES_API_KEY | ''; None (unset) | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:172; src/caty_gateway/doctor.py:244; src/caty_gateway/setup_orchestrator.py:585; src/caty_gateway/setup_orchestrator.py:588; src/caty_gateway/setup_orchestrator.py:701 |
-| CATY_HERMES_URL | 'http://127.0.0.1:8642' | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:171; src/caty_gateway/doctor.py:246 |
+| CATY_HERMES_API_KEY | ''; None (unset) | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:173; src/caty_gateway/doctor.py:244; src/caty_gateway/setup_orchestrator.py:585; src/caty_gateway/setup_orchestrator.py:588; src/caty_gateway/setup_orchestrator.py:701 |
+| CATY_HERMES_URL | 'http://127.0.0.1:8642' | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:172; src/caty_gateway/doctor.py:246 |
 | CATY_HISTORY_DIR | '' | A | local | member env (0600) | src/caty_gateway/history_store.py:27; src/caty_gateway/history_store.py:31; src/caty_gateway/session_links.py:21 |
 | CATY_HISTORY_MAX_TURNS | '0' | C | public | member env (0600) | src/caty_gateway/history_store.py:114 |
 | CATY_HISTORY_MD | '1' | C | public | member env (0600) | src/caty_gateway/history_store.py:216 |
-| CATY_ID | ''; 'caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_config.py:114; src/caty_gateway/caty_gateway.py:1310; src/caty_gateway/caty_gateway.py:1366; src/caty_gateway/caty_gateway.py:185; src/caty_gateway/caty_gateway.py:1862; src/caty_gateway/caty_gateway.py:2036; src/caty_gateway/caty_gateway.py:4534; src/caty_gateway/pairing_store.py:144; src/caty_gateway/share_store.py:115 |
-| CATY_LANG | 'ja' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:165; src/caty_gateway/setup_orchestrator.py:1160 |
-| CATY_NAME | 'Caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/avatar_engine.py:551; src/caty_gateway/caty_gateway.py:186; src/caty_gateway/history_store.py:202; src/caty_gateway/setup_orchestrator.py:126 |
+| CATY_ID | ''; 'caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/caty_config.py:114; src/caty_gateway/caty_gateway.py:1311; src/caty_gateway/caty_gateway.py:1367; src/caty_gateway/caty_gateway.py:186; src/caty_gateway/caty_gateway.py:1863; src/caty_gateway/caty_gateway.py:2037; src/caty_gateway/caty_gateway.py:4535; src/caty_gateway/pairing_store.py:144; src/caty_gateway/share_store.py:115 |
+| CATY_LANG | 'ja' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:166; src/caty_gateway/setup_orchestrator.py:1160 |
+| CATY_NAME | 'Caty'; None (unset) | A | public | member env (0600) | src/caty_gateway/avatar_engine.py:551; src/caty_gateway/caty_gateway.py:187; src/caty_gateway/history_store.py:202; src/caty_gateway/setup_orchestrator.py:126 |
 | CATY_OFFLINE | '' | C | public | member env (0600) | src/caty_gateway/voice_preview.py:51 |
-| CATY_OPENAI_API_KEY | '' | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:175; src/caty_gateway/doctor.py:251; src/caty_gateway/setup_orchestrator.py:701 |
-| CATY_OPENAI_BASE_URL | '' | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:173; src/caty_gateway/doctor.py:249 |
-| CATY_OPENAI_CHAT_HEARTBEAT_SEC | '5' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:215 |
-| CATY_OPENAI_CHAT_MAX_CONCURRENCY | '2' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:214 |
-| CATY_OPENAI_CHAT_TIMEOUT | '60' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:212 |
-| CATY_OPENAI_CHAT_TOKEN | '' | C | secret | member env (0600) | src/caty_gateway/caty_gateway.py:177 |
-| CATY_OPENAI_CHAT_USER_MAX_LEN | '512' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:213 |
-| CATY_OPENAI_MAX_HISTORY_CHARS | '24000' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:176 |
-| CATY_OPENAI_MODEL | '' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:174; src/caty_gateway/doctor.py:255 |
+| CATY_OPENAI_API_KEY | '' | B | secret | member env (0600) | src/caty_gateway/caty_gateway.py:176; src/caty_gateway/doctor.py:251; src/caty_gateway/setup_orchestrator.py:701 |
+| CATY_OPENAI_BASE_URL | '' | B | local | member env (0600) | src/caty_gateway/caty_gateway.py:174; src/caty_gateway/doctor.py:249 |
+| CATY_OPENAI_CHAT_HEARTBEAT_SEC | '5' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:216 |
+| CATY_OPENAI_CHAT_MAX_CONCURRENCY | '2' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:215 |
+| CATY_OPENAI_CHAT_TIMEOUT | '60' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:213 |
+| CATY_OPENAI_CHAT_TOKEN | '' | C | secret | member env (0600) | src/caty_gateway/caty_gateway.py:178 |
+| CATY_OPENAI_CHAT_USER_MAX_LEN | '512' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:214 |
+| CATY_OPENAI_MAX_HISTORY_CHARS | '24000' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:177 |
+| CATY_OPENAI_MODEL | '' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:175; src/caty_gateway/doctor.py:255 |
 | CATY_PAIRING_ALLOW_NONTAILNET | '' | A | public | member env (0600) | src/caty_gateway/pairing_store.py:131 |
 | CATY_PAIRING_DIR | '' | A | local | member env (0600) | src/caty_gateway/pairing_store.py:159 |
 | CATY_PAIRING_LOCKOUT_SECONDS | 60 | B2 | public | member env (0600) | src/caty_gateway/pairing_store.py:127 |
@@ -74,12 +74,12 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_PAIRING_RATE_PER_MIN | 10 | B2 | public | member env (0600) | src/caty_gateway/pairing_store.py:129 |
 | CATY_PAIRING_TTL_SECONDS | 600 | B2 | public | member env (0600) | src/caty_gateway/pairing_store.py:117 |
 | CATY_PRESENCE_MODE2 | '' | C | public | member env (0600) | src/caty_gateway/presence_state.py:8 |
-| CATY_PTT_BRAIN_TIMEOUT | '1800' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:181 |
-| CATY_PTT_JOB_TTL | '2100' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:182 |
-| CATY_PUBLIC_URL | '' | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:2489; src/caty_gateway/caty_gateway.py:2684; src/caty_gateway/doctor.py:105; src/caty_gateway/setup_orchestrator.py:128 |
-| CATY_QR_DELIVERY | 'auto' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:2610; src/caty_gateway/setup_orchestrator.py:129 |
-| CATY_REQUIRE_AUTH | False | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1354 |
-| CATY_SESSION_KEY_PREFIX | 'caty-' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:158 |
+| CATY_PTT_BRAIN_TIMEOUT | '1800' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:182 |
+| CATY_PTT_JOB_TTL | '2100' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:183 |
+| CATY_PUBLIC_URL | '' | A | local | member env (0600) | src/caty_gateway/caty_gateway.py:2490; src/caty_gateway/caty_gateway.py:2685; src/caty_gateway/doctor.py:105; src/caty_gateway/setup_orchestrator.py:128 |
+| CATY_QR_DELIVERY | 'auto' | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:2611; src/caty_gateway/setup_orchestrator.py:129 |
+| CATY_REQUIRE_AUTH | False | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1355 |
+| CATY_SESSION_KEY_PREFIX | 'caty-' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:159 |
 | CATY_SETUP_BACKEND_RECOVERY_TIMEOUT_SECONDS | '120' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:945 |
 | CATY_SETUP_DEBUG | None (unset) | C | public | process-only | src/caty_gateway/setup_orchestrator.py:2094 |
 | CATY_SETUP_HANDOFF_GRACE_SECONDS | '5' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1649 |
@@ -88,21 +88,21 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_SETUP_STATUS_WAIT_SECONDS | '600' | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1791 |
 | CATY_SETUP_SUPERVISED | None (unset) | D | public | process-only | src/caty_gateway/setup_orchestrator.py:1079; src/caty_gateway/setup_orchestrator.py:1576; src/caty_gateway/setup_orchestrator.py:1680; src/caty_gateway/setup_orchestrator.py:1844; src/caty_gateway/setup_orchestrator.py:1896; src/caty_gateway/setup_orchestrator.py:2025 |
 | CATY_SHARE_DIR | '' | A | local | member env (0600) | src/caty_gateway/share_store.py:126 |
-| CATY_STREAM_TTS | ''; None (unset) | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1384; src/caty_gateway/caty_gateway.py:162 |
-| CATY_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:183; src/caty_gateway/caty_gateway.py:4935; src/caty_gateway/cli.py:95 |
+| CATY_STREAM_TTS | ''; None (unset) | C | public | member env (0600) | src/caty_gateway/caty_gateway.py:1385; src/caty_gateway/caty_gateway.py:163 |
+| CATY_TOKEN | '' | A | secret | member env (0600) | src/caty_gateway/caty_gateway.py:184; src/caty_gateway/caty_gateway.py:4936; src/caty_gateway/cli.py:95 |
 | CATY_TOMBSTONE_TTL_DAYS | '7' | C | public | member env (0600) | src/caty_gateway/history_store.py:139 |
-| CATY_TTS_ENGINE | '' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1502 |
-| CATY_TTS_PROXY | 'http://localhost:5100/v1/audio/speech' | C | local | member env (0600) | src/caty_gateway/caty_gateway.py:179 |
-| CATY_TTS_VOICE | '' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:164 |
-| CATY_UNSAFE_DEBUG_LOG_CONTENT | None (unset) | C | public | process-only | src/caty_gateway/caty_gateway.py:685 |
-| CATY_USER_NAME | None (unset) | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:945 |
+| CATY_TTS_ENGINE | '' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1503 |
+| CATY_TTS_PROXY | 'http://localhost:5100/v1/audio/speech' | C | local | member env (0600) | src/caty_gateway/caty_gateway.py:180 |
+| CATY_TTS_VOICE | '' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:165 |
+| CATY_UNSAFE_DEBUG_LOG_CONTENT | None (unset) | C | public | process-only | src/caty_gateway/caty_gateway.py:686 |
+| CATY_USER_NAME | None (unset) | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:946 |
 | CATY_VISION_MODEL | None (unset) | C | public | member env (0600) | src/caty_gateway/vision_describer.py:49 |
 | CATY_VOICE_CATALOG_FETCH_LIMIT | 300 | C | public | member env (0600) | src/caty_gateway/voice_catalog.py:437 |
 | CATY_VOICE_CATALOG_TIMEOUT_SECONDS | 15.0 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:354 |
 | CATY_VOICE_CATALOG_TTL_SECONDS | 300 | C | public | member env (0600) | src/caty_gateway/voice_catalog.py:434 |
 | CATY_VOICE_FILLER_MAX_TEXTS_PER_KIND | None (unset); expression: DEFAULT_MAX_TEXTS_PER_KIND | C | public | member env (0600) | src/caty_gateway/filler_pack.py:335; src/caty_gateway/filler_texts.py:44 |
 | CATY_VOICE_FILLER_RECOVERY_QUARANTINE_RETENTION_SECONDS | expression: DEFAULT_RECOVERY_QUARANTINE_RETENTION_SECONDS | C | public | member env (0600) | src/caty_gateway/filler_pack.py:350 |
-| CATY_VOICE_HINT | None (unset); expression: DEFAULT_VOICE_HINT; expression: THIN_MEMBER_VOICE_HINT | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1280; src/caty_gateway/caty_gateway.py:1301; src/caty_gateway/caty_gateway.py:1305; src/caty_gateway/caty_gateway.py:1367 |
+| CATY_VOICE_HINT | None (unset); expression: DEFAULT_VOICE_HINT; expression: THIN_MEMBER_VOICE_HINT | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:1281; src/caty_gateway/caty_gateway.py:1302; src/caty_gateway/caty_gateway.py:1306; src/caty_gateway/caty_gateway.py:1368 |
 | CATY_VOICE_PREVIEW_CACHE_BYTES | expression: 32 * 1024 * 1024 | C | public | member env (0600) | src/caty_gateway/voice_preview.py:189 |
 | CATY_VOICE_PREVIEW_CACHE_ENTRIES | 128 | C | public | member env (0600) | src/caty_gateway/voice_preview.py:186 |
 | CATY_VOICE_PREVIEW_MAX_BYTES | expression: 2 * 1024 * 1024 | C | public | member env (0600) | src/caty_gateway/voice_preview.py:180 |
@@ -113,7 +113,7 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | CATY_VOICE_PREVIEW_SINGLE_FLIGHT_TIMEOUT_SECONDS | 180 | C | public | member env (0600) | src/caty_gateway/voice_preview.py:201 |
 | CATY_VOICE_PREVIEW_TTL_SECONDS | 604800 | C | public | member env (0600) | src/caty_gateway/voice_preview.py:171 |
 | CODEX_HOME | None (unset) | D | local | process-only | src/caty_gateway/backends/generic_cli.py:100 |
-| FFMPEG_BIN | 'ffmpeg' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:167; src/caty_gateway/doctor.py:170; src/caty_gateway/voice_preview.py:56 |
+| FFMPEG_BIN | 'ffmpeg' | A | public | member env (0600) | src/caty_gateway/caty_gateway.py:168; src/caty_gateway/doctor.py:170; src/caty_gateway/voice_preview.py:56 |
 | FFPROBE_BIN | ''; 'ffprobe' | A | public | member env (0600) | src/caty_gateway/doctor.py:172; src/caty_gateway/voice_preview.py:57 |
 | FISH_API_KEY | '' | C | secret | member env (0600) | src/caty_gateway/tts_fish.py:68; src/caty_gateway/tts_fish.py:72; src/caty_gateway/voice_catalog.py:400; src/caty_gateway/voice_catalog.py:87 |
 | FISH_BASE_URL | 'https://api.fish.audio' | C | public | member env (0600) | src/caty_gateway/tts_fish.py:76 |
@@ -125,7 +125,7 @@ Unknown names are unclassified and make `--check` fail until reviewed in the scr
 | FISH_UNHEALTHY_COOLDOWN_S | 20.0 | C | public | member env (0600) | src/caty_gateway/tts_fish.py:62 |
 | HERMES_HOME | expression: str(self.home / '.hermes') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:717 |
 | HOME | None (unset); expression: str(Path.home()); expression: str(pathlib.Path.home()) | D | local | process-only | src/caty_gateway/cli.py:60; src/caty_gateway/doctor.py:102; src/caty_gateway/setup_orchestrator.py:118 |
-| OPENCLAW_BIN | 'openclaw' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:166; src/caty_gateway/doctor.py:225 |
+| OPENCLAW_BIN | 'openclaw' | B | public | member env (0600) | src/caty_gateway/caty_gateway.py:167; src/caty_gateway/doctor.py:225 |
 | OPENCLAW_GATEWAY_TOKEN | None (unset) | B | secret | member env (0600) | src/caty_gateway/backends/openclaw.py:138; src/caty_gateway/doctor.py:231 |
 | OPENCLAW_HOME | expression: str(self.home / '.openclaw') | D | local | process-only | src/caty_gateway/setup_orchestrator.py:714 |
 | PATH | None (unset); expression: os.defpath | D | local | process-only | src/caty_gateway/doctor.py:122; src/caty_gateway/setup_orchestrator.py:1157; src/caty_gateway/setup_orchestrator.py:235 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caty-gateway"
-version = "0.1.2"
+version = "0.1.3"
 description = "A self-hosted voice and pairing gateway for Caty clients"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/src/caty_gateway/caty_gateway.py
+++ b/src/caty_gateway/caty_gateway.py
@@ -53,6 +53,7 @@ import secrets
 import shutil
 import signal
 import socket
+import socketserver
 import stat
 import subprocess
 import sys
@@ -5781,6 +5782,21 @@ def lan_ip():
         s.close()
 
 
+class _GatewayHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer whose bind skips reverse-DNS lookup (#19).
+
+    HTTPServer resolves the bind address's FQDN after binding; on hosts without
+    fast reverse DNS that blocks for tens of seconds, and the gateway never
+    reads the resolved name. Bind and set the two server attributes directly.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
+
+
 def main(argv=None):
     argv = list(sys.argv[1:] if argv is None else argv)
     if argv and argv[0] not in ("serve", "qr"):
@@ -5846,7 +5862,7 @@ def main(argv=None):
         # it.  §6-2 already routes store unavailability to 503 pairing_disabled,
         # which the handlers do on their own once this stays non-fatal.
         log(f"WARN pairing store unavailable, pairing disabled: {error}")
-    srv = ThreadingHTTPServer((bind_host, PORT), Handler)
+    srv = _GatewayHTTPServer((bind_host, PORT), Handler)
     print("=" * 56)
     print("  Caty gateway")
     print(f"  agent = {AGENT}   STT言語 = {LANG}")

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -357,7 +357,7 @@ class AttachmentMechanismTest(unittest.TestCase):
             cg.share_store, "cleanup_claimed_orphans",
             side_effect=lambda _root: events.append("cleanup"),
         ), mock.patch.object(cg, "_get_neutral_voice_readiness", return_value=Readiness()), mock.patch.object(
-            cg, "ThreadingHTTPServer", Server
+            cg, "_GatewayHTTPServer", Server
         ), mock.patch.object(cg, "load_fillers"), mock.patch.object(
             cg, "report_content_logging_mode"
         ), mock.patch.object(cg, "_pairing_token_configured", return_value=True), mock.patch.object(

--- a/tests/test_pairing_routes.py
+++ b/tests/test_pairing_routes.py
@@ -142,7 +142,7 @@ class PairingRoutesTest(unittest.TestCase):
         fake_server = mock.Mock()
         fake_server.serve_forever.return_value = None
         with mock.patch.object(cg.sys, "argv", ["caty_gateway.py"]), \
-                mock.patch.object(cg, "ThreadingHTTPServer", return_value=fake_server), \
+                mock.patch.object(cg, "_GatewayHTTPServer", return_value=fake_server), \
                 mock.patch.object(cg, "report_content_logging_mode"), \
                 mock.patch.object(cg, "load_fillers"), \
                 redirect_stdout(io.StringIO()):
@@ -158,7 +158,7 @@ class PairingRoutesTest(unittest.TestCase):
         fake_server = mock.Mock()
         fake_server.serve_forever.return_value = None
         with mock.patch.object(cg.sys, "argv", ["caty_gateway.py"]), \
-                mock.patch.object(cg, "ThreadingHTTPServer", return_value=fake_server), \
+                mock.patch.object(cg, "_GatewayHTTPServer", return_value=fake_server), \
                 mock.patch.object(cg, "report_content_logging_mode"), \
                 mock.patch.object(cg, "load_fillers"), \
                 mock.patch.dict(os.environ, {"CATY_REQUIRE_AUTH": "0", "CATY_GATEWAY_BIND": "127.0.0.1"}), \
@@ -194,7 +194,7 @@ class PairingRoutesTest(unittest.TestCase):
         fake_server = mock.Mock()
         fake_server.serve_forever.return_value = None
         with mock.patch.object(cg.sys, "argv", ["caty_gateway.py"]), \
-                mock.patch.object(cg, "ThreadingHTTPServer", return_value=fake_server), \
+                mock.patch.object(cg, "_GatewayHTTPServer", return_value=fake_server), \
                 mock.patch.object(cg, "report_content_logging_mode"), \
                 mock.patch.object(cg, "load_fillers"), \
                 mock.patch.dict(os.environ, {"CATY_GATEWAY_BIND": "127.0.0.1"}), \
@@ -509,7 +509,7 @@ class PairingRoutesTest(unittest.TestCase):
         broken = ps.PairingUnavailable("cannot initialize pairing store root")
         with mock.patch.object(cg.sys, "argv", ["caty_gateway.py"]), \
                 mock.patch.object(cg, "_get_pairing_store", side_effect=broken), \
-                mock.patch.object(cg, "ThreadingHTTPServer", return_value=fake_server), \
+                mock.patch.object(cg, "_GatewayHTTPServer", return_value=fake_server), \
                 mock.patch.object(cg, "report_content_logging_mode"), \
                 mock.patch.object(cg, "load_fillers"), \
                 redirect_stdout(io.StringIO()) as stdout:

--- a/tests/test_require_auth.py
+++ b/tests/test_require_auth.py
@@ -85,7 +85,7 @@ class RequireAuthTest(unittest.TestCase):
             for token in ("", " \t "):
                 os.environ["CATY_GATEWAY_BIND"] = host
                 cg.CATY_TOKEN = token
-                with mock.patch.object(cg, "ThreadingHTTPServer") as server, \
+                with mock.patch.object(cg, "_GatewayHTTPServer") as server, \
                         mock.patch.object(cg, "load_fillers") as fillers, \
                         mock.patch.object(cg, "_get_pairing_config") as pairing:
                     with self.assertRaises(SystemExit) as result:
@@ -99,7 +99,7 @@ class RequireAuthTest(unittest.TestCase):
         for host in ("127.0.0.1", "::1", "localhost"):
             os.environ["CATY_GATEWAY_BIND"] = host
             with ExitStack() as stack:
-                server = stack.enter_context(mock.patch.object(cg, "ThreadingHTTPServer"))
+                server = stack.enter_context(mock.patch.object(cg, "_GatewayHTTPServer"))
                 stack.enter_context(mock.patch.object(cg, "load_fillers"))
                 stack.enter_context(mock.patch.object(cg, "report_content_logging_mode"))
                 stack.enter_context(mock.patch.object(cg, "_get_pairing_store"))

--- a/tests/test_server_bind.py
+++ b/tests/test_server_bind.py
@@ -1,0 +1,53 @@
+import http.server
+import socket
+import socketserver
+from http.server import BaseHTTPRequestHandler
+
+import pytest
+
+from caty_gateway.caty_gateway import _GatewayHTTPServer
+
+
+def _getfqdn_must_not_be_called(*_args, **_kwargs):
+    raise AssertionError("getfqdn must not be called")
+
+
+def _fake_bind(self):
+    self.server_address = ("127.0.0.1", 8123)
+
+
+def test_server_bind_does_not_call_getfqdn_without_socket(monkeypatch):
+    monkeypatch.setattr(socket, "getfqdn", _getfqdn_must_not_be_called)
+    monkeypatch.setattr(socketserver.TCPServer, "server_bind", _fake_bind)
+    server = _GatewayHTTPServer(
+        ("127.0.0.1", 8123), BaseHTTPRequestHandler, bind_and_activate=False
+    )
+    try:
+        server.server_bind()
+        assert server.server_name == "127.0.0.1"
+        assert server.server_port == 8123
+    finally:
+        server.server_close()
+
+
+def test_server_bind_real_loopback_socket_skips_getfqdn(monkeypatch):
+    monkeypatch.setattr(socket, "getfqdn", _getfqdn_must_not_be_called)
+    server = _GatewayHTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    try:
+        assert server.server_port == server.socket.getsockname()[1]
+        assert server.server_name == "127.0.0.1"
+    finally:
+        server.server_close()
+
+
+def test_stock_threading_http_server_calls_getfqdn(monkeypatch):
+    monkeypatch.setattr(socket, "getfqdn", _getfqdn_must_not_be_called)
+    monkeypatch.setattr(socketserver.TCPServer, "server_bind", _fake_bind)
+    server = http.server.ThreadingHTTPServer(
+        ("127.0.0.1", 8123), BaseHTTPRequestHandler, bind_and_activate=False
+    )
+    try:
+        with pytest.raises(AssertionError, match="getfqdn must not be called"):
+            server.server_bind()
+    finally:
+        server.server_close()


### PR DESCRIPTION
Lane for #19 (size S–M, ship-relevant: runtime behaviour, release v0.1.3). Does not close #19 by keyword; the Issue is closed after MERGED is declared with the v0.1.3 tag + Release. Follow-up of #13 / PR #18.

## What changed

- **Root cause.** `http.server.HTTPServer.server_bind` runs `self.server_name = socket.getfqdn(host)` after `bind()` and before `listen()`. On hosts without a fast reverse-DNS path (hosted GitHub macOS runners: 36.29 / 36.23 / 36.47 s per start, PR #18 run) that call blocks for the resolver timeout, so the gateway is unreachable for ~36 s after launch. The gateway never reads `server_name` (grep: no reader in `src/`).
- **Fix** (`src/caty_gateway/caty_gateway.py`): `_GatewayHTTPServer(ThreadingHTTPServer)` overrides `server_bind` to `socketserver.TCPServer.server_bind(self)` + `server_name = host` / `server_port = port` — CPython's implementation minus the `getfqdn` call. `main()` constructs it at the single call site (formerly `ThreadingHTTPServer((bind_host, PORT), Handler)`). `allow_reuse_address`, `daemon_threads`, `request_queue_size`, handler, bind host/port, banner and `serve_forever` are untouched. `import socketserver` added.
- **Tests** (`tests/test_server_bind.py`, new): (1) socket-free unit test — `socket.getfqdn` monkeypatched to raise, `TCPServer.server_bind` stubbed, `server_bind()` sets name/port without calling getfqdn; (2) real loopback bind on port 0, `server_port == getsockname()[1]`, socket closed in `finally`; (3) negative control — stock `http.server.ThreadingHTTPServer.server_bind` trips the same monkeypatch (proves the test discriminates).
- **Existing mocks** (`tests/test_require_auth.py`, `tests/test_pairing_routes.py`, `tests/test_attachments.py`): the 7 `mock.patch.object(cg, "ThreadingHTTPServer")` targets now patch `_GatewayHTTPServer` (what `main()` constructs); otherwise those tests would open a real socket / block in `serve_forever`. Found by the Codex writer's self-check.
- **`docs/env.md`** regenerated with `tools/env-inventory.py --output` (the auto-generated inventory pins source line numbers; the new import shifts them by one). The writer had compensated by deleting a blank line — reverted in favour of regenerating the file.
- **`pyproject.toml`** 0.1.2 → 0.1.3.

## Files touched (declared set = diff)

`src/caty_gateway/caty_gateway.py`, `tests/test_server_bind.py` (new), `tests/test_require_auth.py`, `tests/test_pairing_routes.py`, `tests/test_attachments.py`, `docs/env.md`, `pyproject.toml`

`git diff --stat origin/main...4f0d2d1` (main = `320a083`): 7 files, +123 / −54 (under the 250-line pr-size gate). `src/caty_gateway/caty_gateway.py` is on `risk_paths_auth` and `pyproject.toml` on `risk_paths_gates` → `risk-reviewed` is required from the owner.

## 完了記録 (Completion record)

candidate SHA: 4f0d2d1
implementer: Codex (GPT, profile sol, via sitter-run; source + new test module) — Alpha (Claude Code / Fable 5.1) repointed the 7 existing mock targets, regenerated `docs/env.md`, bumped the version, restored one blank line, ran the socket-binding tests locally (Codex's sandbox cannot bind loopback) and committed the declared paths
reviewer: Kimi K3 (GO; 2 minors, both non-blocking) / Grok 4.6 (GO-WITH-MINORS; 2 minors) / Opus 5 (GO-WITH-MINORS; 1 pre-existing out-of-scope item it labelled MAJOR + 3 minors). All three seats independently converged on the same remaining call site (`_bind_qr_delivery_server`, stock `HTTPServer`) → filed as follow-up #23.
identity check: 別モデル（writer = Codex sol (GPT); seats per `loom-seats --size S --absent codex-sol --absent glm-5.3` = Grok 4.6 (substitute for GLM 5.3, 429 quota until 2026-09-10) / Opus 5 / Kimi K3, `same_family_seats: []`; Alpha is orchestrator/inspector, not a vote）
CI: at 4f0d2d1 (2026-09-06): `test-lint / test` PASS (1m05s) https://github.com/caty-ai/caty-gateway/actions/runs/34010496705/job/101425354614 · `test-lint / test-macos` PASS (1m03s, `1152 passed`, 0 warnings) https://github.com/caty-ai/caty-gateway/actions/runs/34010496705/job/101425354549 · `test-lint / lint`, `gitleaks`, `history-check`, `pr-size`, `watch`, `risk-review-gate / detect-risk-paths` PASS; `test-macos-skip` / `strip-size-exempt` skipped as designed. `risk-review-gate / risk-review-gate` is **red by design** (https://github.com/caty-ai/caty-gateway/actions/runs/34010496655/job/101425369311): `caty_gateway.py` (auth) and `pyproject.toml` (gates) are risk paths, so the job fails closed until an owner applies `risk-reviewed` to this head — not a test failure, no T-4 exception claimed.
release: v0.1.3（出荷相当: 利用者が動かす挙動 = server startup path; annotated tag `v0.1.3` on the squash commit + GitHub Release after merge）
previous release: v0.1.2 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.2（履行済み・tag on `320a083`, Release created by release-sync run 34010035257, 2026-09-06; PR #21 lane）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| `ThreadingHTTPServer` construction no longer calls `socket.getfqdn` on the bind address; behaviour otherwise unchanged | PASS | `grep -n getfqdn src/caty_gateway/caty_gateway.py` → no hits; `grep -n "HTTPServer(" src/caty_gateway/caty_gateway.py` → one construction site, `_GatewayHTTPServer((bind_host, PORT), Handler)`. `python3 -B -m pytest tests/test_server_bind.py -q -p no:cacheprovider` → `3 passed in 0.09s` (2026-09-06; includes the real loopback bind and the negative control that fails on stock `ThreadingHTTPServer`). Subclass body is CPython's `HTTPServer.server_bind` with `getfqdn(host)` → `host`; no other attribute touched. |
| macOS lane's readiness warnings from `tests/test_setup_process_e2e.py` disappear (no `gateway readiness took …` RuntimeWarning in the `test-lint / test-macos` warnings summary; run URL recorded) | PASS | `test-lint / test-macos` at 4f0d2d1, 2026-09-06: https://github.com/caty-ai/caty-gateway/actions/runs/34010496705/job/101425354549 — pytest summary line `1152 passed, 252 subtests passed in 36.23s` (**no warnings**; `grep "readiness took"` over the job log → 0 hits). Contrast, same lane on the previous head `67cd1e7` (PR #21, before this fix): `1149 passed, 3 warnings, 252 subtests passed in 134.28s` with three `RuntimeWarning: gateway readiness took 35.58s / 35.32s / 35.19s on darwin` (https://github.com/caty-ai/caty-gateway/actions/runs/34009503920/job/101422718785). Local (macOS 25.5, 2026-09-06): `tests/test_setup_process_e2e.py` ×3 → `1 passed in 0.46s / 0.38s / 0.36s`, no RuntimeWarning. |
| `make test` green on ubuntu + macOS lanes; no new environment variable | PASS | CI at 4f0d2d1 (2026-09-06): `test-lint / test` (ubuntu) PASS 1m05s https://github.com/caty-ai/caty-gateway/actions/runs/34010496705/job/101425354614 · `test-lint / test-macos` PASS 1m03s (job above; was 2m40s on the previous head). Local `make test PYTHON=<venv>` at 4f0d2d1 (2026-09-06): `1152 passed, 252 subtests passed in 40.62s`, `suites: declared=55 executed=55 skipped=0`, `scrub-audit: 0 findings`, `env-inventory: 122 names, no drift`, publication gate OK. CI lanes: see CI field. New env vars: `CATY_` occurrences in `caty_gateway.py` 147 → 147 (writer's check); `env-inventory --check` exit 0. |

### Review (3 seats, fresh context, blind, read-only; F1–F5 fixed checks)

- **Kimi K3** — GO. F1 PASS (no `server_name` / `server_port` readers in `src/`; single construction site :5865; `socketserver` imported; no `getfqdn` in module), F2 N/A, F3 PASS (compared with CPython's `HTTPServer.server_bind` via `inspect.getsource`: only `getfqdn(host)` → `host`; `allow_reuse_address=True`, `daemon_threads=True`, `request_queue_size=5`, `address_family=AF_INET` inherited unchanged), F4 PASS (`3 passed`; negative control real; loopback port 0 + `finally` close; e2e `1 passed in 0.36s` no RuntimeWarning), F5 PASS (7-file declared set == diff; `env-inventory --check` no drift; tree clean after runs). MINORs: (1) `_bind_qr_delivery_server` (:2789) still uses stock `HTTPServer` → same stall class for `caty-gateway qr`, out of #19 scope; (2) unit tests pin the class, not the `main()` call site — mitigated by the 7 retargeted mocks + e2e.
- **Grok 4.6** — GO-WITH-MINORS. F1–F5 all PASS with the same evidence (adds: `server_bind.__code__.co_names` has no `getfqdn`; launchd `ProgramArguments` / systemd `ExecStart` both enter `main()` → no second serve construction site; `allow_reuse_port=False` unchanged). MINORs: (1) same QR delivery server site; (2) call-site pin gap — a revert to `ThreadingHTTPServer(...)` keeps the 3 unit tests green and the e2e test only *warns* above 2 s on fast-DNS hosts; optional fix: assert `main` constructs `_GatewayHTTPServer`, or monkeypatch `socket.getfqdn` around the e2e spawn.
- **Opus 5** — GO-WITH-MINORS. F1 PASS (stdlib reads `server_name` only in `CGIHTTPRequestHandler.run_cgi`, unused), F2 N/A, F3 PASS (byte-equivalent to CPython 3.14.3 minus `getfqdn`), F4 PASS (call-site revert is caught by `test_require_auth.py:110` opening a real socket), F5 PASS. Findings: (1) **labelled MAJOR, pre-existing, out of scope, not blocking** — `caty-gateway qr` pays the same ~36 s stall before printing the QR URL while the pairing expiry clock runs (:2789); (2) MINOR — a reverted call site would hang in `serve_forever()` under the mocks rather than fail on an assertion; suggest `side_effect=AssertionError` in one test; (3) MINOR — docstring could state `server_name` is the bind address, not an FQDN; (4) informational — subclass sits ~3000 lines from the other bind helper. Not verified by Opus: the hosted macOS warnings summary (Alpha verified it, see the Done-when table) and the full `make test` gate (Alpha ran it).
- **Alpha's disposition (orchestrator, not a vote):** candidate kept at `4f0d2d1`. The convergent item (QR delivery server) is a second call site outside #19's Done-when; filed as **#23** (size S, ship-relevant) with the call-site fail-fast test as an optional item, rather than widening this risk-path diff after review. Docstring wording (Opus 3) folded into #23's lane too. No delta round needed.
- GLM 5.3 remains absent (429 quota until 2026-09-10); `loom-seats --size S --absent codex-sol --absent glm-5.3` → Grok 4.6 substitute / Opus 5 / Kimi K3, `status: GO`.

- Seat outputs are kept in the session scratchpad; the summary above is the record.

### Owner actions needed before merge

1. **`risk-reviewed` label** — `caty_gateway.py` (risk_paths_auth) and `pyproject.toml` (risk_paths_gates) are risk paths, so `risk-review-gate` stays red until an owner on `.github/risk-reviewers.txt` applies the label to this head (`4f0d2d1`). Apply it **after** the PR body is final (an edit or a new push voids it). https://github.com/caty-ai/caty-gateway/pull/22
2. Merge decision (squash).

No `size-exempt` needed (123 + 54 < 250).

### After merge (Alpha)

Annotated tag `v0.1.3` on the squash commit → GitHub Release (release-sync creates it from the tag subject; Alpha verifies) → MERGED comment with the tag URL on #19 → close #19. Note for #9: if the first PyPI publish has not happened yet, publishing `0.1.3` instead of `0.1.2` is the owner's call (both tags exist).

### Not in this lane

`.github/workflows/**` (#9), PyPI publish (owner), MCP subcommand (#12), the e2e test budget (#13 left it at 60 s; unchanged here), the QR delivery server's bind path and the call-site fail-fast test (#23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
