### PR TITLE
ci(publish): bump twine 6.1.0 -> 7.0.0 so twine check accepts Metadata-Version 2.5 (#9)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
           REQUESTED_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          python3 -m pip install -q 'build==1.2.2.post1' 'twine==6.1.0'
+          python3 -m pip install -q 'build==1.2.2.post1' 'twine==7.0.0'
           python3 -m build
           ls -l dist
           python3 -m twine check --strict dist/*


### PR DESCRIPTION
Lane for #9 (size S, CI wiring only — one pin). Does not close #9; that Issue closes after the first successful PyPI publish.

## What changed

`.github/workflows/publish.yml` line 84: `'twine==6.1.0'` → `'twine==7.0.0'`. Nothing else.

## Why

The owner's first publish attempt (`gh workflow run publish.yml -f version=0.1.3`, run https://github.com/caty-ai/caty-gateway/actions/runs/34011465750) failed in the **build** job at `twine check --strict`:

```
Checking dist/caty_gateway-0.1.3-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Current hatchling (the unpinned build backend) writes `Metadata-Version: 2.5` into the wheel; twine 6.1.0 predates that metadata version. Reproduced locally from the `v0.1.3` tag (2026-09-06, `git archive v0.1.3` → `python -m build`):

```
Metadata-Version: 2.5
twine 6.1.0 → InvalidDistribution: '2.5' is not a valid metadata version
twine 7.0.0 → Checking dist/caty_gateway-0.1.3-py3-none-any.whl: PASSED
              Checking dist/caty_gateway-0.1.3.tar.gz: PASSED
```

The PyPI pending-publisher registration was never reached and is unaffected. `workflow_dispatch` takes the workflow definition from `main`, so after merge the same command works without a new tag.

## Files touched (declared set = diff)

`.github/workflows/publish.yml` — `git diff --stat origin/main...6670ac2` (main = `5b7d305`): 1 file, +1 / −1.

## 完了記録 (Completion record)

candidate SHA: 6670ac2
implementer: Alpha (Claude Code / Fable 5.1) — direct edit (yaml, one pin); no Codex involvement
reviewer: Grok 4.6 (GO) / Kimi K3 (GO) / Gemini 3.8 Flash (GO; static diff-only seat — headless `agy` has no tools, network checks marked NOT VERIFIABLE). All three converged on one non-blocking gap: PR-time CI never runs `build` + `twine check`.
identity check: 別モデル（writer = Fable 5.1; seats per `loom-seats --size S --absent opus-5 --absent glm-5.3` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash; GLM 5.3 absent with 429 quota until 2026-09-10）
CI: at 6670ac2 (2026-09-06): `test-lint / test`, `test-lint / test-macos`, `test-lint / lint`, `gitleaks`, `history-check`, `pr-size`, `watch`, `risk-review-gate / detect-risk-paths` all PASS (run https://github.com/caty-ai/caty-gateway/actions/runs/34012155412); `risk-review-gate / risk-review-gate` red by design (`.github/workflows/**` is a risk path → owner label; https://github.com/caty-ai/caty-gateway/actions/runs/34012155448/job/101429740471). The changed workflow itself only runs on `workflow_dispatch`; its proof is the owner's publish re-run after merge.
release: N/A（③ CI・開発環境の配線のみ — the publish workflow's own check-tool pin; no artifact, behaviour or user-facing norm changes. The artifacts it will publish are the already-released `v0.1.3`）
previous release: v0.1.3 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.3（履行済み・tag on `5b7d305`, release-sync run 34010962166, PR #22 lane）

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| `twine check --strict` accepts the artifacts built from the release tag | PASS (local) / CI proof on the next owner-triggered publish run | Local, 2026-09-06: built from `v0.1.3` with `build==1.2.2.post1`; `twine 7.0.0` → `PASSED` ×2 (wheel, sdist); `twine 6.1.0` on the same files → the exact CI error. The workflow only runs on `workflow_dispatch`, so the on-runner proof is the owner's re-run after merge (URL to be posted on #9). |
| No other change to the publish pipeline | PASS | Diff is one token on one line; `build` pin, checkout-by-tag, sdist payload guard, environment `pypi`, OIDC-only publish step untouched. |

### Review (3 seats, fresh context, blind, read-only; short delivery)

- **Grok 4.6** — GO. F1 PASS (`pip index versions twine` → 7.0.0 latest; wheel METADATA `Requires-Dist: packaging>=26.1`, `Requires-Python: >=3.10`; packaging 26.x carries PEP 794 / Metadata 2.5; no other twine pin in the workflow), F3 PASS (only the build-job pip pin; publish job uses the bundled twine of `pypa/gh-action-pypi-publish@v1.14.2`), F4 PASS with gap (PR CI never builds/checks dist → owner-only `workflow_dispatch` was the first gate), F5 PASS (`--name-status` = one file; `.scrub-allow` covers `uses:` pins, untouched). Worst modes: changelog 7.0.0 does not change README rendering (drops never-standard Metadata 2.0, accepts 2.5); hatchling remains unpinned as the producer — the bump aligns the checker with current hatchling + PyPI rather than masking it; pinning hatchling is optional hardening.
- **Kimi K3** — GO. Same F1–F5 with the decisive cross-check: `pypa/gh-action-pypi-publish` v1.14.2 (SHA `dc37677`) `runtime.txt` pins `twine==7.0.0` with the note "v7 is needed to support metadata v2.5 including PEP 794" — so after this bump the check step and the upload step run the same twine. `readme-renderer>=35.0` floor unchanged between 6.1.0 and 7.0.0; Python 3.10+ vs runner 3.12 OK. Gap (non-blocking): add a PR CI step `python3 -m build && twine check --strict dist/*`.
- **Gemini 3.8 Flash** (static, diff-only) — GO, no findings. F1 NOT VERIFIABLE for network; F3 PASS (semantics unchanged; publish independent of this twine); F4 gap noted (same follow-up); F5 PASS (one line, no SHA / env / secrets).
- **Alpha's disposition (writer, not a vote):** candidate kept at `6670ac2`. The convergent follow-up (PR-time build + `twine check --strict`) is filed as a separate Issue after merge rather than widening this one-line unblock; hatchling pinning left as an optional note there.
- GLM 5.3 absent (429 quota until 2026-09-10); `loom-seats --size S --absent opus-5 --absent glm-5.3` → Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`.

### Owner actions

1. `risk-reviewed` label if `risk-review-gate` asks for it (`.github/workflows/**` may be on `risk_paths_gates`) — apply after the body is final. https://github.com/caty-ai/caty-gateway/pull/24
2. Merge (squash).
3. Then re-run the publish: `gh workflow run publish.yml --repo caty-ai/caty-gateway -f version=0.1.3` → approve the `pypi` environment → paste the green run URL on #9.

### Not in this lane

Pinning `hatchling`, adding a PR-time build+twine-check job (follow-up candidate if a seat asks for it), PyPI publish itself (owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
