### PR TITLE
server: QR delivery server binds without socket.getfqdn via shared mixin (#23); pyproject 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caty-gateway"
-version = "0.1.3"
+version = "0.1.4"
 description = "A self-hosted voice and pairing gateway for Caty clients"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/src/caty_gateway/caty_gateway.py
+++ b/src/caty_gateway/caty_gateway.py
@@ -2786,7 +2786,7 @@ def _bind_qr_delivery_server(handler, addresses):
     last_error = None
     for address in addresses:
         try:
-            return HTTPServer((address, 0), handler)
+            return _QRDeliveryHTTPServer((address, 0), handler)
         except OSError as error:
             last_error = error
     raise OSError(
@@ -5782,12 +5782,11 @@ def lan_ip():
         s.close()
 
 
-class _GatewayHTTPServer(ThreadingHTTPServer):
-    """ThreadingHTTPServer whose bind skips reverse-DNS lookup (#19).
+class _NoReverseDNSBindMixin:
+    """Bind without reverse DNS lookup (#19, #23).
 
-    HTTPServer resolves the bind address's FQDN after binding; on hosts without
-    fast reverse DNS that blocks for tens of seconds, and the gateway never
-    reads the resolved name. Bind and set the two server attributes directly.
+    ``server_name`` is the bind address, not an FQDN; nothing in this module
+    reads it.
     """
 
     def server_bind(self):
@@ -5795,6 +5794,19 @@ class _GatewayHTTPServer(ThreadingHTTPServer):
         host, port = self.server_address[:2]
         self.server_name = host
         self.server_port = port
+
+
+class _GatewayHTTPServer(_NoReverseDNSBindMixin, ThreadingHTTPServer):
+    """ThreadingHTTPServer whose bind skips reverse-DNS lookup (#19).
+
+    HTTPServer resolves the bind address's FQDN after binding; on hosts without
+    fast reverse DNS that blocks for tens of seconds, and the gateway never
+    reads the resolved name. Bind and set the two server attributes directly.
+    """
+
+
+class _QRDeliveryHTTPServer(_NoReverseDNSBindMixin, HTTPServer):
+    """Single-threaded QR delivery server whose bind skips reverse DNS."""
 
 
 def main(argv=None):

--- a/tests/test_require_auth.py
+++ b/tests/test_require_auth.py
@@ -85,7 +85,7 @@ class RequireAuthTest(unittest.TestCase):
             for token in ("", " \t "):
                 os.environ["CATY_GATEWAY_BIND"] = host
                 cg.CATY_TOKEN = token
-                with mock.patch.object(cg, "_GatewayHTTPServer") as server, \
+                with mock.patch.object(cg, "_GatewayHTTPServer", side_effect=AssertionError("server must not be constructed")) as server, \
                         mock.patch.object(cg, "load_fillers") as fillers, \
                         mock.patch.object(cg, "_get_pairing_config") as pairing:
                     with self.assertRaises(SystemExit) as result:

--- a/tests/test_server_bind.py
+++ b/tests/test_server_bind.py
@@ -5,7 +5,12 @@ from http.server import BaseHTTPRequestHandler
 
 import pytest
 
-from caty_gateway.caty_gateway import _GatewayHTTPServer
+from caty_gateway.caty_gateway import (
+    _GatewayHTTPServer,
+    _NoReverseDNSBindMixin,
+    _QRDeliveryHTTPServer,
+    _bind_qr_delivery_server,
+)
 
 
 def _getfqdn_must_not_be_called(*_args, **_kwargs):
@@ -51,3 +56,51 @@ def test_stock_threading_http_server_calls_getfqdn(monkeypatch):
             server.server_bind()
     finally:
         server.server_close()
+
+
+def test_qr_delivery_server_bind_does_not_call_getfqdn_without_socket(monkeypatch):
+    monkeypatch.setattr(socket, "getfqdn", _getfqdn_must_not_be_called)
+    monkeypatch.setattr(socketserver.TCPServer, "server_bind", _fake_bind)
+    server = _QRDeliveryHTTPServer(
+        ("127.0.0.1", 8123), BaseHTTPRequestHandler, bind_and_activate=False
+    )
+    try:
+        server.server_bind()
+        assert server.server_name == "127.0.0.1"
+        assert server.server_port == 8123
+    finally:
+        server.server_close()
+
+
+def test_qr_delivery_server_is_single_threaded():
+    assert not issubclass(_QRDeliveryHTTPServer, socketserver.ThreadingMixIn)
+    assert issubclass(_QRDeliveryHTTPServer, http.server.HTTPServer)
+
+
+def test_bind_qr_delivery_server_constructs_no_getfqdn_class(monkeypatch):
+    monkeypatch.setattr(socket, "getfqdn", _getfqdn_must_not_be_called)
+    server = _bind_qr_delivery_server(BaseHTTPRequestHandler, ["127.0.0.1"])
+    try:
+        assert isinstance(server, _QRDeliveryHTTPServer)
+        assert server.server_name == "127.0.0.1"
+        assert server.server_port == server.socket.getsockname()[1]
+    finally:
+        server.server_close()
+
+
+def test_stock_http_server_calls_getfqdn(monkeypatch):
+    monkeypatch.setattr(socket, "getfqdn", _getfqdn_must_not_be_called)
+    monkeypatch.setattr(socketserver.TCPServer, "server_bind", _fake_bind)
+    server = http.server.HTTPServer(
+        ("127.0.0.1", 8123), BaseHTTPRequestHandler, bind_and_activate=False
+    )
+    try:
+        with pytest.raises(AssertionError, match="getfqdn must not be called"):
+            server.server_bind()
+    finally:
+        server.server_close()
+
+
+def test_both_servers_share_the_mixin_bind():
+    assert _GatewayHTTPServer.server_bind is _NoReverseDNSBindMixin.server_bind
+    assert _QRDeliveryHTTPServer.server_bind is _NoReverseDNSBindMixin.server_bind


### PR DESCRIPTION
Closes #23 (follow-up of #19 / PR #22).

## What

`caty-gateway qr` still built its one-shot delivery server with the stock `http.server.HTTPServer`, whose `server_bind` calls `socket.getfqdn` — the same ~36 s reverse-DNS stall #19 removed from the main server, paid here before the QR URL is printed while the pairing expiry clock runs.

- The `server_bind` override from #19 is extracted into `_NoReverseDNSBindMixin` and shared by `_GatewayHTTPServer` (threading, behaviour unchanged) and a new single-threaded `_QRDeliveryHTTPServer(HTTPServer)`.
- `_bind_qr_delivery_server()` constructs `_QRDeliveryHTTPServer`; nothing else changes there (same address loop, same `OSError` fallthrough and message).
- Tests (`tests/test_server_bind.py`, existing 3 kept): QR bind path getfqdn-must-not-be-called (socket-free), stock `HTTPServer` negative control, MRO identity pin, single-threaded pin, real loopback bind through `_bind_qr_delivery_server`. `tests/test_require_auth.py:88` mock gets `side_effect=AssertionError` so a reverted `main()` call site fails fast (Issue optional item).
- `pyproject.toml` 0.1.3 → 0.1.4. `docs/env.md` did not drift: the new classes sit after the last env pin (`env-inventory --check` → `122 names, no drift`).

`git diff --stat origin/main...c38f083` (main = `5b7d305`): 4 files, +74 / −9 (under the 250-line pr-size gate). `src/caty_gateway/caty_gateway.py` is on `risk_paths_auth` and `pyproject.toml` on `risk_paths_gates` → `risk-reviewed` is required from the owner.

## 完了記録 (Completion record)

candidate SHA: c38f083
implementer: Codex (GPT, `-m gpt-5.6-sol -c model_reasoning_effort=medium`, via sitter-run; source + tests) — Alpha (Claude Code / Fable 5.1) bumped the version, ran `make test` locally including the socket-binding tests (Codex's sandbox cannot bind loopback), reset the hook's `.omx/` artifact and committed the declared paths
reviewer: Grok 4.6 (GO; 0 findings) / Kimi K3 (GO; 3 INFO) / Opus 5 (GO; 3 INFO). No CRITICAL / MAJOR / MINOR from any seat; no delta round.
identity check: 別モデル（writer = Codex sol (GPT); seats per `loom-seats --size S --absent codex-sol --absent glm-5.3` = Grok 4.6 (substitute for GLM 5.3, 429 quota until 2026-09-10) / Opus 5 / Kimi K3, `same_family_seats: []`; Alpha is orchestrator/inspector, not a vote）
CI: at c38f083 (2026-09-06): `test-lint / test` (ubuntu) PASS 59s https://github.com/caty-ai/caty-gateway/actions/runs/34012192854/job/101429820684 (`1157 passed, 252 subtests passed in 25.50s`) · `test-lint / test-macos` PASS 47s https://github.com/caty-ai/caty-gateway/actions/runs/34012192854/job/101429820800 (`1157 passed, 252 subtests passed in 25.68s`, no `readiness took` warning) · `test-lint / lint`, `gitleaks`, `history-check`, `pr-size`, `watch`, `risk-review-gate / detect-risk-paths`, `apply-visibility-labels` PASS; `test-macos-skip` / `strip-size-exempt` skipped as designed. `risk-review-gate / risk-review-gate` is **red by design** (https://github.com/caty-ai/caty-gateway/actions/runs/34012193609/job/101429856821): risk paths fail closed until an owner applies `risk-reviewed` to this head — not a test failure, no T-4 exception claimed.
release: v0.1.4（出荷相当: 利用者が動かす挙動 = `caty-gateway qr` startup path; annotated tag `v0.1.4` on the squash commit + GitHub Release after merge）
previous release: v0.1.3 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.3（履行済み・PR #22 lane, 2026-09-06）

### Done when → 結果

| Done when 項目 | 結果 | 証拠（コマンド or 手順 + 観測結果 + 日付） |
|---|---|---|
| `_bind_qr_delivery_server()` binds without `socket.getfqdn` (shared mixin; QR server single-threaded) | PASS | `grep -n getfqdn src/caty_gateway/caty_gateway.py` → no hits; `grep -n "HTTPServer(" src/…` → two construction sites (`:2789` `_QRDeliveryHTTPServer`, `:5877` `_GatewayHTTPServer`). `__mro__`: both classes resolve `server_bind` to `_NoReverseDNSBindMixin.server_bind`; `issubclass(_QRDeliveryHTTPServer, ThreadingMixIn)` → False (verified independently by all 3 seats, 2026-09-06). |
| unit test asserting the QR delivery server's bind path does not call `getfqdn` | PASS | `tests/test_server_bind.py:61` (socket-free, getfqdn monkeypatched to raise) + `:80` (real loopback bind through `_bind_qr_delivery_server`, getfqdn poisoned) + `:91` stock `HTTPServer` negative control + `:104` MRO identity pin + `:75` single-threaded pin. Local (venv, 2026-09-06): `pytest tests/test_server_bind.py tests/test_require_auth.py tests/test_qr_delivery.py` → `44 passed, 4 subtests passed`. Opus 5 ran the revert mutation (patch `_QRDeliveryHTTPServer` → stock `HTTPServer`) → `AssertionError: getfqdn must not be called` (REVERT CAUGHT). |
| optional: one existing test patches `cg._GatewayHTTPServer` with `side_effect=AssertionError` | PASS | `tests/test_require_auth.py:88` — consistent with the existing `server.assert_not_called()` at `:94`; test passes (all 3 seats checked). |
| `make test` green on ubuntu + macOS; no new environment variable | PASS | CI at c38f083 (2026-09-06): ubuntu `1157 passed`, macOS `1157 passed` (URLs in the CI field; +5 tests vs 1152 at v0.1.3). Local `make test PYTHON=<venv>` → exit 0, `suites: declared=55 executed=55 skipped=0`, `scrub-audit: 0 findings`, `env-inventory: 122 names, no drift`, publication gate OK. Diff adds no `os.environ` / `CATY_` line (Grok/Kimi/Opus each grepped). |

### Review (3 seats, fresh context, blind, read-only; F1–F5 fixed checks)

- **Grok 4.6** — GO. F1–F5 all PASS: declared 4-file set == diff; production constructors only at `:2789` / `:5877`; `server_name` written only by the mixin, QR URL uses `server_address`; mixin body == CPython 3.14 `HTTPServer.server_bind` minus `getfqdn`; `_bind_qr_delivery_server` differs by class name only, `handle_request()` loop at `:2969` still serial; call-site revert cannot slip (poisoned getfqdn raises, and mixin-second MRO fails the `is` pin); `git diff -w --stat` == full stat; env.md not in diff. Ran 6 test modules → `172 passed, 26 subtests`. Findings: none. Not verified: hosted CI, 3.10 interpreter.
- **Kimi K3** — GO. F1–F5 all PASS with the same evidence (adds: mixin body byte-identical to pre-#23 `server_bind` via `git show 5b7d305:…`; `git diff --check` clean; all 15 existing mock targets still exist). Full `make test` with `PYTHONPATH=$PWD/src` → exit 0, `1157 passed`. INFO ×3: MRO `is` pin + single-threaded pin cover both named worst-failure shapes; `_GatewayHTTPServer` docstring duplicates the mixin's explanation (harmless); its first `make test` showed 4 subprocess-test failures caused by its own relative `PYTHONPATH=src`, resolved with an absolute path — not a candidate defect.
- **Opus 5** — GO. F1–F5 all PASS; ran the revert mutation and the wrong-MRO simulation, both caught by the suite; full suite in the worktree `1157 passed, 252 subtests passed in 60.56s`; `allow_reuse_address` / `address_family` unchanged on both classes. INFO ×3: mixin calls `socketserver.TCPServer.server_bind` explicitly (mirrors CPython; a future wrapping base between mixin and TCPServer would be bypassed — no change requested); `_bind_qr_delivery_server` references a class defined ~3000 lines later (legal; keeps env.md pins from drifting — trade accepted); "nothing reads `server_name`" is an unpinned invariant (acceptable for size S). Not verified: hosted CI (Alpha verified, see CI field), end-to-end wall-clock of `caty-gateway qr`.
- **Alpha's disposition (orchestrator, not a vote):** candidate kept at `c38f083`. All seats GO with INFO only; nothing to fold. The three INFOs are recorded here for future readers; none changes runtime behaviour.
- GLM 5.3 remains absent (429 quota until 2026-09-10); `loom-seats --size S --absent codex-sol --absent glm-5.3` → Grok 4.6 substitute / Opus 5 / Kimi K3, `status: GO`.
- Note on the writer: `~/.codex/config.toml` defines no `[profiles.sol]`, so the model was pinned explicitly with `-m gpt-5.6-sol` instead of `--profile sol` (a `--profile` with no definition silently falls back to the default model).

- Seat outputs are kept in the session scratchpad; the summary above is the record.

### Owner actions needed before merge

1. **`risk-reviewed` label** — `caty_gateway.py` (risk_paths_auth) and `pyproject.toml` (risk_paths_gates) are risk paths, so `risk-review-gate` stays red until an owner on `.github/risk-reviewers.txt` applies the label to this head (`c38f083`). Apply it **after** this body is final (an edit or a new push voids it). https://github.com/caty-ai/caty-gateway/pull/25
2. Merge decision (squash).

No `size-exempt` needed (74 + 9 < 250).

### After merge (Alpha)

Annotated tag `v0.1.4` on the squash commit → GitHub Release (release-sync creates it from the tag subject; Alpha verifies) → MERGED comment with the tag URL on #23 → close #23. Note for #9: if the first PyPI publish has not happened yet, publishing `0.1.4` is the owner's call.

### Not in this lane

`.github/workflows/**` (#9), PyPI publish (owner), MCP subcommand (#12), README, the QR delivery handler body (unchanged, outside the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
