### PR TITLE
docs: publish runbook (dispatch on the tag, --ref vX.Y.Z); publish.yml fails closed off-tag (#27)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@
 # with owner=caty-ai, repository=caty-gateway, workflow=publish.yml, environment=pypi (issue #9),
 # and the `pypi` GitHub environment protected by required reviewers + tag-only deployment branches.
 # No API token is stored anywhere; the `pypi` environment is the gate.
+# Runbook: docs/engineering.md "Publishing a release" (dispatch on the tag: --ref vX.Y.Z).
 name: Publish to PyPI
 
 on:
@@ -36,6 +37,15 @@ jobs:
             echo "::error::version '$REQUESTED_VERSION' is not a plain SemVer-style version (fail-closed)"
             exit 1
           fi
+      - name: Require dispatch on the release tag (--ref vX.Y.Z)
+        # The pypi environment only deploys from tag: v*; without --ref the run starts on main and the
+        # publish job is rejected after a successful build. Fail closed here instead (docs/engineering.md).
+        if: ${{ github.ref != format('refs/tags/v{0}', github.event.inputs.version) }}
+        env:
+          REQUESTED_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          echo "::error::dispatched on '$GITHUB_REF', not on refs/tags/v$REQUESTED_VERSION; re-run with: gh workflow run publish.yml --repo caty-ai/caty-gateway --ref v$REQUESTED_VERSION -f version=$REQUESTED_VERSION (fail-closed)"
+          exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: refs/tags/v${{ github.event.inputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Require dispatch on the release tag (--ref vX.Y.Z)
         # The pypi environment only deploys from tag: v*; without --ref the run starts on main and the
         # publish job is rejected after a successful build. Fail closed here instead (docs/engineering.md).
+        # Keep this step after "Validate version syntax": the echo below relies on REQUESTED_VERSION being charset-checked.
         if: ${{ github.ref != format('refs/tags/v{0}', github.event.inputs.version) }}
         env:
           REQUESTED_VERSION: ${{ github.event.inputs.version }}

--- a/docs/engineering.ja.md
+++ b/docs/engineering.ja.md
@@ -197,6 +197,23 @@ make gate        # 公開ゲート単体（個人 URL・denylist・selftest）
 
 backend の追加手順は [CONTRIBUTING.md](../CONTRIBUTING.md) にあります。
 
+### リリースの公開
+
+オーナー専用です。PyPI への配布は `.github/workflows/publish.yml` の Trusted Publishing で行い、トークンは保存しません。GitHub 環境 `pypi` は承認者が必要で、`tag: v*` の ref からしかデプロイできないため、ワークフローは `main` ではなく**タグの上で**起動します。
+
+1. `main` の `pyproject.toml` で `[project].version` を上げ、annotated tag と GitHub Release を作ります（`git tag -a vX.Y.Z` → `git push origin vX.Y.Z` → `gh release create vX.Y.Z`）
+2. そのタグを指定してワークフローを起動します:
+
+   ```sh
+   gh workflow run publish.yml --repo caty-ai/caty-gateway --ref vX.Y.Z -f version=X.Y.Z
+   ```
+
+   `--ref` を省くと `main` で起動し、`build` job がその不一致で fail-closed に止まります（このガードを入れる前は `publish` job が `Branch "main" is not allowed to deploy to pypi` で拒否されていました）
+3. Actions で該当 run を開き、`pypi` 環境を承認します
+4. `https://pypi.org/project/caty-gateway/X.Y.Z/` で確認します（`pip install caty-gateway==X.Y.Z`）
+
+ワークフロー定義は `main` ではなくタグ時点のものが使われます。`publish.yml` を直したら、次のタグから効きます。
+
 ### Private scrub list
 
 個人名や内部パスの検査リストは、Git 管理外の `<root>/.scrub-private` に置きます。

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -197,6 +197,23 @@ make gate        # publication gate alone (personal URLs, denylist, selftest)
 
 The procedure for adding a backend is in [CONTRIBUTING.md](../CONTRIBUTING.md).
 
+### Publishing a release
+
+Owner-only. PyPI is fed by `.github/workflows/publish.yml` through Trusted Publishing (no stored token). The `pypi` GitHub environment requires a reviewer and only deploys from `tag: v*` refs, so the run must be dispatched **on the tag**, not on `main`.
+
+1. Bump `[project].version` in `pyproject.toml` on `main`, then cut the annotated tag and the GitHub Release (`git tag -a vX.Y.Z` → `git push origin vX.Y.Z` → `gh release create vX.Y.Z`)
+2. Dispatch the workflow on that tag:
+
+   ```sh
+   gh workflow run publish.yml --repo caty-ai/caty-gateway --ref vX.Y.Z -f version=X.Y.Z
+   ```
+
+   Without `--ref` the run starts on `main`; the `build` job fails closed on that mismatch (before this guard, the `publish` job was rejected with `Branch "main" is not allowed to deploy to pypi`)
+3. Open the run under Actions and approve the `pypi` environment
+4. Verify `https://pypi.org/project/caty-gateway/X.Y.Z/` (`pip install caty-gateway==X.Y.Z`)
+
+The workflow definition is taken from the tag, not from `main`: a fix to `publish.yml` only takes effect from the next tag.
+
 ### Private scrub list
 
 Keep local detectors in the git-ignored `<root>/.scrub-private`, or set


### PR DESCRIPTION
Lane for #27 (size S, docs + one fail-closed CI guard). Closes #27.

## What changed

- `docs/engineering.md` / `docs/engineering.ja.md` — new "Publishing a release" / 「リリースの公開」 subsection under Development: annotated tag + GitHub Release first → `gh workflow run publish.yml --repo caty-ai/caty-gateway --ref vX.Y.Z -f version=X.Y.Z` → approve the `pypi` environment → verify `https://pypi.org/project/caty-gateway/X.Y.Z/`; one line that the workflow definition is taken from the tag, so a `publish.yml` fix only takes effect from the next tag.
- `.github/workflows/publish.yml` — new step in the `build` job, after "Validate version syntax" and before checkout: `if: github.ref != format('refs/tags/v{0}', inputs.version)` → `::error::` with the corrected re-run command, `exit 1`. Uses the runner default `$GITHUB_REF` and the existing `REQUESTED_VERSION` step env (no new environment variable; `env-inventory: 122 names, no drift`). Plus a header comment pointing at the runbook.

## Why

The second publish attempt in #9 (run https://github.com/caty-ai/caty-gateway/actions/runs/34013109700) was dispatched on `main` because `--ref` was omitted; `build` passed and `publish` was rejected by the environment rule `tag: v*` with 0 steps and no log. The working form (used for 0.1.4, run https://github.com/caty-ai/caty-gateway/actions/runs/34037641520) lived only in Issue comments. Now it is in the docs, and the same mistake fails in the `build` job with an actionable message.

## Files touched (declared set = diff)

`docs/engineering.md`, `docs/engineering.ja.md`, `.github/workflows/publish.yml` — `git diff --stat origin/main...5c5c276` (main = `f7798ef`): 3 files, +45 / −0.

## 完了記録 (Completion record)

candidate SHA: 5c5c276 (= reviewed 7d531d4 + one comment line in `publish.yml` adopting a seat NIT; `git diff 7d531d4..5c5c276` = 1 file, +1)
implementer: Alpha (Claude Code / Fable 5.1) — direct edit (docs + yaml); no Codex involvement
reviewer: Grok 4.6 (GO, findings none) / Kimi K3 (GO, 2 NIT) / Gemini 3.8 Flash (GO, findings none) — all F1–F5 PASS at 7d531d4
identity check: 別モデル（writer = Fable 5.1; seats per `loom-seats --size S --absent opus-5 --absent glm-5.3` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`; GLM 5.3 absent with 429 quota until 2026-09-10）
CI: at 7d531d4 (2026-09-06): `test-lint / test`, `test-lint / test-macos`, `test-lint / lint`, `gitleaks`, `history-check`, `pr-size`, `watch`, `risk-review-gate / detect-risk-paths`, `apply-visibility-labels` all PASS (run https://github.com/caty-ai/caty-gateway/actions/runs/34039288216); `risk-review-gate / risk-review-gate` red by design (`.github/workflows/**` is a risk path → owner label; https://github.com/caty-ai/caty-gateway/actions/runs/34039288152/job/101502998896). Re-run at 5c5c276: same set all PASS (https://github.com/caty-ai/caty-gateway/actions/runs/34039559955), `risk-review-gate` red by design (https://github.com/caty-ai/caty-gateway/actions/runs/34039559953/job/101503743209). The changed workflow itself only runs on `workflow_dispatch`; its on-runner proof is the owner's next publish (and the guard's negative proof would be a deliberate `--ref main` dispatch, not done here).
release: N/A（① 規範 docs + ③ CI 配線 — the runbook and a guard in the owner-only publish workflow; no artifact, behaviour or user-facing norm of the shipped package changes）
previous release: v0.1.4 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.4（履行済み・PyPI https://pypi.org/project/caty-gateway/0.1.4/ ）

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| `docs/engineering.md` (+ `.ja.md`) gain "Publishing a release": tag + Release → exact `gh workflow run … --ref vX.Y.Z -f version=X.Y.Z` → approve `pypi` → verify PyPI URL; workflow file taken from the tag | PASS | Diff: 17 lines each, 4 numbered steps in that order + the closing line about the tag; EN/JA 1:1 (Grok F4 / Gemini F4 PASS) |
| optional: `publish.yml` fails closed with a clear `::error::` when `github.ref` ≠ `refs/tags/v${version}` | PASS | New step in `build` (publish.yml lines 40–50); seats F2: branch `v0.1.5`, bare tag name, `rc` versions, lightweight tag all fail closed here or in the existing later steps; no bypass found |
| `make test` green (publication gate) | PASS (local + CI) | Local at 7d531d4: pytest 1155 passed (2 deselected = Issue #28, pre-existing macOS host collision identical on `main`), `make scrub env-check gate lint` green, `env-inventory: 122 names, no drift`; CI `test-lint / test` + `test-macos` PASS (run above) |

### Review (3 seats, fresh context, blind, read-only, short delivery; packet = brief + diff + full new publish.yml)

- **Grok 4.6** — GO, findings none. F1–F5 PASS: `github.ref` / `$GITHUB_REF` / `format()` semantics confirmed; worst mode constructed (branch named `v*`, short ref) fails closed; skip-green on the happy path.
- **Kimi K3** — GO, F1–F5 PASS, 2 NIT: (1) docs `gh release create vX.Y.Z` has no `--repo` while the dispatch line has it — **not adopted**: the release is cut from the local clone (tag push precedes it), the dispatch line carries `--repo` because it is the one command copy-pasted from anywhere; (2) the guard's injection safety depends on the charset validator running first — **adopted** as a comment line (`5c5c276`).
- **Gemini 3.8 Flash** (static, inline packet, no tools) — GO, findings none. F1–F5 PASS; notes env-mapped shell vars prevent expression injection and the JA/EN texts match 1:1.
- **Alpha's disposition (writer, not a vote):** candidate `5c5c276`. Side finding while running the suite locally: the suite SIGTERMs real macOS daemons via `os.killpg` on fake pids → filed as #28, not touched here (outside the declared file set).

### Owner actions

1. `risk-reviewed` label (`.github/workflows/**` is a risk path) — apply after this body is final. https://github.com/caty-ai/caty-gateway/pull/29
2. Merge (squash). No tag (release N/A).

### Not in this lane

#26 (PR-time `build` + `twine check --strict`; starts serially after this merge), #28 (test host collision), PyPI publish itself (owner), README, Homebrew tap, #12 MCP, branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
