### PR TITLE
ci: package-check on every PR — build + twine check --strict with the publish.yml pins (#26)

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build sdist and wheel, then twine check --strict
         run: |
           set -euo pipefail
-          python3 -m pip install -q 'build==1.2.2.post1' 'twine==7.0.0'   # same pins as publish.yml
+          python3 -m pip install -q 'build==1.2.2.post1' 'twine==6.1.0'   # NEGATIVE CONTROL — temporary, reverted before merge
           python3 -m build
           ls -l dist
           python3 -m twine check --strict dist/*

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build sdist and wheel, then twine check --strict
         run: |
           set -euo pipefail
-          python3 -m pip install -q 'build==1.2.2.post1' 'twine==6.1.0'   # NEGATIVE CONTROL — temporary, reverted before merge
+          python3 -m pip install -q 'build==1.2.2.post1' 'twine==7.0.0'   # same pins as publish.yml
           python3 -m build
           ls -l dist
           python3 -m twine check --strict dist/*

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -1,0 +1,28 @@
+# Build the sdist + wheel on every PR and run `twine check --strict`, so packaging-metadata drift
+# (e.g. a new hatchling writing a Metadata-Version the pinned twine rejects, issue #9) is caught
+# here instead of in the owner-only publish run.
+# The `build` / `twine` pins MUST equal the ones in publish.yml ("Build sdist and wheel, then check them").
+name: Package Check
+on:
+  pull_request:
+permissions: {contents: read}
+concurrency: {group: 'package-check-${{ github.event.pull_request.number }}', cancel-in-progress: true}
+jobs:
+  package-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+      - name: Build sdist and wheel, then twine check --strict
+        run: |
+          set -euo pipefail
+          python3 -m pip install -q 'build==1.2.2.post1' 'twine==7.0.0'   # same pins as publish.yml
+          python3 -m build
+          ls -l dist
+          python3 -m twine check --strict dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
           REQUESTED_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
-          python3 -m pip install -q 'build==1.2.2.post1' 'twine==7.0.0'
+          python3 -m pip install -q 'build==1.2.2.post1' 'twine==7.0.0'   # same pins as package-check.yml (PR-time check)
           python3 -m build
           ls -l dist
           python3 -m twine check --strict dist/*

--- a/.scrub-allow
+++ b/.scrub-allow
@@ -10,5 +10,6 @@ Tailscale
 ~/\.openclaw/openclaw\.json
 # PROVENANCE table rows contain expected SHA-256 source and output digests.
 assets/PROVENANCE.md	|
-# publish.yml pins every action by its 40-hex commit SHA (supply-chain pin, not a secret).
-.github/workflows/publish.yml	- uses: 
+# publish.yml / package-check.yml pin every action by its 40-hex commit SHA (supply-chain pin, not a secret).
+.github/workflows/publish.yml	- uses:
+.github/workflows/package-check.yml	- uses:

--- a/.scrub-allow
+++ b/.scrub-allow
@@ -11,5 +11,5 @@ Tailscale
 # PROVENANCE table rows contain expected SHA-256 source and output digests.
 assets/PROVENANCE.md	|
 # publish.yml / package-check.yml pin every action by its 40-hex commit SHA (supply-chain pin, not a secret).
-.github/workflows/publish.yml	- uses:
+.github/workflows/publish.yml	- uses: 
 .github/workflows/package-check.yml	- uses:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.32.0"]  # pinned for reproducible metadata (issue #26); bump deliberately, package-check.yml + publish.yml verify it
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Lane for #26 (size S, CI wiring). Closes #26.

## What changed

- `.github/workflows/package-check.yml` (new) — on every `pull_request`, ubuntu, `contents: read` only: `pip install 'build==1.2.2.post1' 'twine==7.0.0'` → `python -m build` → `twine check --strict dist/*`. Same action SHAs and Python 3.12 as `publish.yml`. Sibling workflow rather than a job inside `test-lint.yml`, because that file is a thin caller of the handbook's reusable workflow.
- `.github/workflows/publish.yml` — one comment on the pin line pointing at `package-check.yml` (the new file carries the reverse pointer), so the two pins are kept equal by review.
- `pyproject.toml` — `[build-system].requires = ["hatchling==1.32.0"]` (current release; the version that writes `Metadata-Version: 2.5`, verified against twine 7.0.0). Adopted because two seats asked for it (Issue's optional item).
- `.scrub-allow` — one scoped entry so the 40-hex action pins in the new workflow pass `tools/scrub-audit.sh` (same shape as the existing publish.yml entry).

## Why

The first PyPI publish (#9) failed in `publish.yml`'s `build` job: unpinned hatchling had moved to Metadata 2.5 and `twine==6.1.0` rejected it. Nothing on the PR path built the distribution, so the owner-only dispatch was the first gate. Now every PR builds and checks the artifacts with the exact pins the publish job uses, and the build backend is pinned so the metadata cannot drift between a green PR and the publish run.

## Files touched (declared set = diff)

`.github/workflows/package-check.yml`, `.github/workflows/publish.yml`, `pyproject.toml`, `.scrub-allow` — `git diff --stat origin/main...7a443d3` (main = `edd27e7`): 4 files, +32 / −3. Branch history also contains the throw-away negative-control commit `334649a` and its revert (see below); the squash merge carries none of it.

## 完了記録 (Completion record)

candidate SHA: 7a443d3 (= reviewed 3b0f3e9 + hatchling pin + `.scrub-allow` trailing-space restore, both requested by seats; `git diff 3b0f3e9..7a443d3` = 2 files, +2 / −2)
implementer: Alpha (Claude Code / Fable 5.1) — direct edit (yaml / toml / allowlist); no Codex involvement
reviewer: Grok 4.6 (GO, findings none) / Kimi K3 (GO-WITH-MINOR: pin hatchling; NIT: allowlist trailing space) / Gemini 3.8 Flash (GO-WITH-MINOR: pin hatchling) — all F1–F5 PASS at 3b0f3e9; both MINORs adopted in 7a443d3
identity check: 別モデル（writer = Fable 5.1; seats per `loom-seats --size S --absent opus-5 --absent glm-5.3` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`; GLM 5.3 absent with 429 quota until 2026-09-10）
CI: at 7a443d3 (2026-09-06): **`package-check` PASS** (https://github.com/caty-ai/caty-gateway/actions/runs/34041623848 — this is Done-when item 1, proven on the PR itself), `test-lint / test`, `test-lint / test-macos`, `test-lint / lint`, `gitleaks`, `history-check`, `pr-size`, `risk-review-gate / detect-risk-paths`, `apply-visibility-labels` all PASS; `risk-review-gate / risk-review-gate` red by design (`.github/workflows/**` is a risk path → owner label; https://github.com/caty-ai/caty-gateway/actions/runs/34041624080/job/101509343009).
negative control: commit `334649a` set `twine==6.1.0` on this branch → `package-check` **FAIL** with the exact #9 error `InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version` (https://github.com/caty-ai/caty-gateway/actions/runs/34041340211); reverted in `2f9234e` (tree identical to 3b0f3e9) → `package-check` PASS (https://github.com/caty-ai/caty-gateway/actions/runs/34041471631).
release: N/A（③ CI・開発環境の配線のみ — a PR-time check and a build-backend pin equal to the version already in use; no artifact, behaviour or user-facing norm of the shipped package changes）
previous release: v0.1.4 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.4（履行済み・PyPI https://pypi.org/project/caty-gateway/0.1.4/ ）

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| PR CI runs `pip install 'build==<pin>' 'twine==<same pin>' && python -m build && twine check --strict dist/*` on ubuntu | PASS | `package-check` job green on this PR at 7a443d3 (run above); red with the #9 error under the negative control |
| twine / build pins are the same values in both workflows (single place or cross-referencing comment) | PASS | `grep -h "build==\|twine==" .github/workflows/*.yml` → identical `build==1.2.2.post1` `twine==7.0.0` on both lines, each commented with the other file's name (Grok F1 / Kimi F1 / Gemini F1 PASS) |
| optional: pin `hatchling` in `[build-system].requires` | PASS (adopted) | `hatchling==1.32.0`; local `python -m build` resolved exactly that, `twine check --strict` PASSED ×2; CI `package-check` PASS at 7a443d3 |
| `make test` unaffected; no new environment variable | PASS | Local at 7a443d3: pytest 1155 passed (2 deselected = Issue #28, pre-existing macOS host collision, identical on `main`), `scrub-audit` 0 findings, `make env-check gate lint` green, `env-inventory: 122 names, no drift`; CI `test-lint / test` + `test-macos` PASS |

### Review (3 seats, fresh context, blind, read-only, short delivery; packet = brief + candidate diff + full new workflow + test-lint.yml)

- **Grok 4.6** — GO, findings none. F1: SHAs byte-identical to publish.yml, `.scrub-allow` tab is a real tab; F2: skipping the publish-only filename / sdist-payload gates at PR time is acceptable; F4: would leave hatchling unpinned as a canary (overruled by the two seats below; the check job still acts as the canary when the pin is bumped).
- **Kimi K3** — GO-WITH-MINOR. MINOR: unpinned hatchling leaves a window where publish can still drift after a green PR → **adopted** (`hatchling==1.32.0`). NIT: the publish.yml allow entry lost its trailing space → **adopted** (restored, entry byte-identical to main).
- **Gemini 3.8 Flash** (static, inline packet, no tools) — GO-WITH-MINOR. MINOR: pin hatchling for reproducible isolated builds → adopted (same change).
- **Alpha's disposition (writer, not a vote):** candidate `7a443d3`. The delta after review is exactly the two seat requests; re-verified locally and on CI.

### Owner actions

1. `risk-reviewed` label (`.github/workflows/**` is a risk path) — apply after this body is final. https://github.com/caty-ai/caty-gateway/pull/30
2. Merge (squash). No tag (release N/A).

### Not in this lane

PyPI publish itself (owner), #28 (test host collision), README, Homebrew tap, #12 MCP, branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
