### PR TITLE
test: FakeProcess no longer hands out real-looking pids; mock os.killpg in the terminate tests (#28)

### DIFF
--- a/tests/test_claude_backend.py
+++ b/tests/test_claude_backend.py
@@ -1,5 +1,6 @@
 import json
 import os
+import signal
 import stat
 import subprocess
 import sys
@@ -80,10 +81,9 @@ class ScriptedStream:
 
 
 class FakeProcess:
-    _next_pid = 1000
-
     def __init__(self, stdout_events=(), stderr_events=(), returncode=0):
         self.returncode = returncode
+        # Only tests with mocked process-group signaling should assign a PID.
         self.pid = None
         self.terminated = False
         self.killed = False
@@ -91,8 +91,6 @@ class FakeProcess:
         self._done = threading.Event()
         self._open_streams = 2
         self._lock = threading.Lock()
-        FakeProcess._next_pid += 1
-        self.pid = FakeProcess._next_pid
         self.stdout = ScriptedStream(stdout_events, on_finish=self._stream_finished)
         self.stderr = ScriptedStream(stderr_events, on_finish=self._stream_finished)
 
@@ -311,11 +309,33 @@ class ClaudeCodeBackendTest(unittest.TestCase):
         backend = self.backend()
         proc = FakeProcess(stdout_events=[(1.0, json.dumps({"ignored": True}) + "\n")], stderr_events=[(1.0, "")], returncode=0)
 
-        with mock.patch.object(backend, "_spawn_stream_once", return_value=proc):
+        def killpg(pid, sig):
+            self.assertEqual(pid, proc.pid)
+            {signal.SIGTERM: proc.terminate, signal.SIGKILL: proc.kill}[sig]()
+
+        with mock.patch("caty_gateway.backends.claude.os.killpg", side_effect=killpg) as killpg_mock, \
+                mock.patch.object(backend, "_spawn_stream_once", return_value=proc):
+            proc.pid = 2**22 + 1
             with self.assertRaises(ClaudeStreamTimeout):
                 list(backend.openai_stream("hi", "meetmate:user", 0))
 
+        killpg_mock.assert_called_once_with(proc.pid, signal.SIGTERM)
         self.assertTrue(proc.terminated or proc.killed)
+
+    def test_terminate_stream_process_without_pid_uses_fallback(self):
+        backend = self.backend()
+        proc = FakeProcess()
+        self.assertIsNone(proc.pid)
+
+        with mock.patch.object(proc, "poll", return_value=None), \
+                mock.patch("caty_gateway.backends.claude.os.killpg") as killpg_mock, \
+                mock.patch("caty_gateway.backends.claude.os.kill") as kill_mock:
+            backend._terminate_stream_process(proc)
+
+        self.assertTrue(proc.terminated)
+        self.assertFalse(proc.killed)
+        killpg_mock.assert_not_called()
+        kill_mock.assert_not_called()
 
     def test_openai_stream_close_terminates_running_process(self):
         backend = self.backend()
@@ -334,11 +354,18 @@ class ClaudeCodeBackendTest(unittest.TestCase):
             returncode=0,
         )
 
-        with mock.patch.object(backend, "_spawn_stream_once", return_value=proc):
+        def killpg(pid, sig):
+            self.assertEqual(pid, proc.pid)
+            {signal.SIGTERM: proc.terminate, signal.SIGKILL: proc.kill}[sig]()
+
+        with mock.patch("caty_gateway.backends.claude.os.killpg", side_effect=killpg) as killpg_mock, \
+                mock.patch.object(backend, "_spawn_stream_once", return_value=proc):
+            proc.pid = 2**22 + 1
             gen = backend.openai_stream("hi", "meetmate:user", 5)
             self.assertEqual(next(gen), "first")
             gen.close()
 
+        killpg_mock.assert_called_once_with(proc.pid, signal.SIGTERM)
         self.assertTrue(proc.terminated or proc.killed)
 
     def test_openai_stream_raises_for_empty_success(self):


### PR DESCRIPTION
Lane for #28 (size S, test-only). Closes #28.

## What changed

- `tests/test_claude_backend.py` only. `FakeProcess.pid` now defaults to `None` (the `_next_pid = 1000` counter is gone). The two terminate tests assign an obviously fake pid (`2**22 + 1`, above Linux `pid_max` and the macOS pid space) and patch `caty_gateway.backends.claude.os.killpg`; the mock checks the pid, marks the fake process terminated/killed for SIGTERM/SIGKILL, and the test asserts `killpg` was called once with `(pid, SIGTERM)`. A new test `test_terminate_stream_process_without_pid_uses_fallback` covers the `pid=None` branch (`proc.terminate()` called, `os.killpg` / `os.kill` not called).

## Why

`FakeProcess` handed out pids 1001, 1002, … and `_terminate_stream_process` calls the real `os.killpg` whenever the pid is truthy. On macOS those pgids are live same-user system daemons, so `make test` signalled real processes and the two assertions failed deterministically (Ubuntu CI was green only because nothing owned the pids on the runner). `src/` is untouched — the helper's behaviour is unchanged.

## Files touched (declared set = diff)

`tests/test_claude_backend.py` — `git diff --stat origin/main...5ee8645` (main = `8c67770`): 1 file, +33 / −6. Nothing else in the tree (the `.omx/` line the Codex sandbox appends to `.gitignore` was reverted before commit).

## 完了記録 (Completion record)

candidate SHA: 5ee8645
implementer: Codex (GPT-6 Astra, medium, `--sandbox workspace-write`, via sitter-run) — test file only; commit by Alpha as alpha-mbp-bridge
reviewer: Grok 4.6 (GO, findings none) / Kimi K3 (GO, 3 NITs) / Gemini 3.8 Flash (GO, 2 NITs) — all F1–F5 PASS at 5ee8645; no MAJOR, no delta needed
identity check: 別モデル（writer = Codex Astra; seats per `loom-seats --size S --absent glm-5.3 --absent codex-sol --absent opus-5` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`; GLM 5.3 absent with 429 quota until 2026-09-10; codex-sol excluded as same family as the writer; opus-5 excluded as same family as the adjudicator, same as PR #30）
CI: at 5ee8645 (2026-09-06): `test-lint / test`, **`test-lint / test-macos`**, `test-lint / lint`, `package-check`, `gitleaks`, `history-check`, `pr-size`, `risk-review-gate / detect-risk-paths`, `risk-review-gate / risk-review-gate`, `apply-visibility-labels`, `watch` all PASS (https://github.com/caty-ai/caty-gateway/pull/32/checks). No risk path touched → no `risk-reviewed` label needed.
negative control: with `_terminate_stream_process` monkey-patched to a no-op, all three tests (`timeout_terminates`, `close_terminates`, `without_pid_uses_fallback`) FAIL (3/3) — the mocks did not make them tautological. Grok / Kimi / Gemini each argued the same independently (F4).
release: N/A（③ テストのみ — no artifact, behaviour or user-facing norm of the shipped package changes）
previous release: v0.1.4 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.4（履行済み・PyPI https://pypi.org/project/caty-gateway/0.1.4/ ）

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| the two tests no longer reach the real `os.killpg` / `os.kill` (patch and assert the fake pid, or exercise the `pid=None` fallback explicitly) | PASS (both) | `killpg_mock.assert_called_once_with(proc.pid, signal.SIGTERM)` in both tests; new explicit `pid=None` fallback test; every other `FakeProcess` keeps `pid=None` (Grok / Kimi traced all constructions, F2 PASS) |
| `make test` green on macOS and Ubuntu | PASS | local macOS at 5ee8645: `make test` → **1158 passed, 252 subtests passed**, exit 0 (first green full run on a Mac); CI `test-lint / test` (ubuntu) + `test-lint / test-macos` PASS |
| no real process is signalled by the suite | PASS | no test path reaches an unmocked `os.killpg` with a pid; the only pid used is `2**22 + 1` (ESRCH even if leaked — Kimi F5 / Grok F5) |

### Review (3 seats, fresh context, blind, read-only; packet = brief + diff + full post-fix test file + unchanged `_terminate_stream_process`)

- **Grok 4.6** — GO, findings none. Re-ran the file (17 passed). Note: the SIGKILL wait-timeout branch is mapped in the mock but not exercised; acceptable for this Done-when.
- **Kimi K3** — GO. NITs: inner `assertEqual` inside the side_effect is redundant (swallowed by the helper's `except Exception`, surfaces via `assert_called_once_with`); patching `claude.os.killpg` patches the global `os` module for the `with` duration (safe, no concurrency); `dict[sig]` `KeyError` could carry a clearer message. Re-ran the file (17 passed, tree clean).
- **Gemini 3.8 Flash** (static, inline packet, no tools) — GO. NITs: duplicated `killpg` helper in the two tests; `os.kill` patch in the fallback test is defensive only (the helper never calls `os.kill`).
- **Alpha's disposition (writer lane owner, not a vote):** candidate `5ee8645` unchanged. All five NITs are style/defence-in-depth at size S and none changes what the tests prove; not adopted, recorded here.

### Owner actions

1. Merge (squash). No label needed (no risk path). No tag (release N/A③).

### Not in this lane

`src/` changes (a pgid-ownership check in `_terminate_stream_process` would be a behaviour change → separate Issue, release ①), #12 MCP design note, #2 smoke, #4 owner items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
