### PR TITLE
docs: design note for the caty-gateway mcp add-on (#12) — owner GO pending, no implementation

### DIFF
--- a/docs/design/mcp-addon.md
+++ b/docs/design/mcp-addon.md
@@ -1,68 +1,75 @@
 # Design note — `caty-gateway mcp` (add-on, not scheduled)
 
-Status: design note for Issue #12. **No implementation until the owner says GO.** Size estimate at the end.
+Status: design note for Issue #12, revision 2 (after a 3-seat review of r1). **No implementation until the owner says GO.** Size estimate at the end.
 
 ## Purpose
 
-Let an agent that is already running on the PC (Claude Code, Codex CLI) reach the paired CatyPhone from inside its session: send an image or PDF to the phone, speak a short status line, or ask whether the phone is paired and present. This is an add-on next to the core, in the same spirit as the avatar engine (design Q9): the phone-initiated voice flow stays exactly as it is, and an MCP server is never the way the phone reaches the agent.
+Let an agent that is already running on the PC (Claude Code, Codex CLI) reach the paired CatyPhone from inside its session: put a picture or page on the phone screen, later speak a short status line, and ask whether the gateway is up and reachable. This is an add-on next to the core, in the same spirit as the avatar engine (design Q9): the phone-initiated voice flow stays exactly as it is, and an MCP server is never the way the phone reaches the agent.
 
 Why MCP cannot be the core (recorded in #12): MCP servers are tool boxes the agent calls. They cannot start a conversation when the phone speaks, and Ollama / LM Studio are not MCP clients.
 
 ## Shape
 
-- New subcommand `caty-gateway mcp`, registered in `build_parser()` in `src/caty_gateway/cli.py` next to `push` and `doctor`.
-- The subcommand runs a stdio MCP server. It is a thin client of the running gateway: every tool call becomes an HTTP request to the local gateway, the same way `caty-gateway push` does today. The MCP process holds no state and opens no listening socket.
-- The agent's MCP config points at the command (`caty-gateway mcp --member <name>`), so the token and the gateway URL are resolved the way `qr --member` already resolves the installed service environment.
+- New subcommand `caty-gateway mcp`, registered in `build_parser()` in `src/caty_gateway/cli.py` next to `push` and `doctor`, dispatched with the same lazy-import pattern (`cli.py` special-cases `push` today).
+- The subcommand runs a stdio MCP server that is a thin HTTP client of the running gateway, the same way `caty-gateway push` is. It holds no state, opens no listening socket, and imports nothing from the gateway daemon's in-memory state (it cannot: it is a separate process).
+- `--member <name>` loads the installed service environment the way `qr --member` does (copy that env-load, do not parse `push` argv), which yields `CATY_TOKEN` and the gateway URL.
+- **stdout is JSON-RPC only.** `caty_push.send_event` prints its result JSON to stdout and returns an exit code, so it is not reusable as-is; the HTTP request part is extracted into a small helper (`caty_push._request_event` or similar) that returns the decoded response and raises on error, and `send_event` keeps its CLI behaviour on top of it. Logging goes to stderr.
 
-## Tools (v1: exactly three)
+## Tools
+
+### v1 (this design; two tools)
 
 | Tool | Arguments | Returns | Gateway path it reuses |
 |---|---|---|---|
-| `caty.push_image` | `path` (local file, image or PDF), `caption` (string, optional), `session` (optional) | `{ok, share_id, event_key}` or `{ok:false, error}` | file → share store (`share_store.py`), then `caty_push.send_event(args, token, "media", payload)` → `POST /push` handled by `_do_push` in `caty_gateway.py` (kind `media`, audience = the member) |
-| `caty.say` | `text` (≤ 280 chars), `session` (optional) | `{ok, event_key}` or `{ok:false, error}` | **needs a new push kind `say`** in `_do_push` (today only `open_url` and `media` are accepted) and a matching handler on the phone; TTS itself stays on the phone side or reuses `tts_fish.synthesize` on the PC, to be decided in the implementation Issue |
-| `caty.status` | none | `{paired, member, presence, last_turn_at, gateway_url}` | `GET /health` (auth-gated when `require_auth_enabled()`), pairing state from `pairing_store.load_config`, presence from `presence_state` |
+| `caty.push_image` | `url` (http/https, already reachable from the phone), `title` (≤200 chars; if omitted, the last path segment of the URL), `media_type` (`image` / `video` / `youtube`, optional), `session` (optional) | the gateway's own `POST /push` reply `{ok, id, duplicate, session_id, session_id_source}`, or `{ok:false, error}` with the redacted message | `POST /push` kind `media`, handled by `_do_push` in `caty_gateway.py` (allow-list `open_url` / `media`, `url` must be http(s) without userinfo, `title` required, `media_type` optional), auth via `_require_write_auth`; audience = the member |
+| `caty.status` | none | `{gateway_up, agent, identity, member, gateway_url, pending_pairings}` | `GET /health` → `{ok, agent}` (auth-gated when `require_auth_enabled()`); `GET /identity` → `identity_payload()` (id, name, accent colour, voice engine); `PairingStore.live_count()` from `pairing_store.py` = number of **unclaimed** QR credentials (a successful claim deletes the record and leaves a `consumed` tombstone, so the store does not say "paired: yes") |
 
-Every tool returns a JSON object; failures are returned as `ok:false` with the same redacted message `caty_push._error_message` produces today (token never echoed).
+`push_image` in v1 therefore does what `caty-gateway push media` does today, from inside the agent, and nothing more. Local file paths are **not** accepted in v1: `share_store.py` is session-bound, single-use staging for **app → agent** shares (`POST /share`, consumed by the voice turn), and the gateway has no route that serves a PC-local file to the phone. Adding one is new server surface (phase 2).
+
+Idempotency: `PushEventQueue.publish_with_status` treats an `event_key` as a no-op only when kind, payload and audience are identical; a different payload under the same key is a 409 `event_key conflict`. The tool derives `event_key` from `sha256(url + title + media_type)` and sends exactly that payload, so a retried call is a no-op and a changed title is a conflict, which is surfaced as `ok:false`.
+
+### phase 2 (separate Issues; each is new gateway surface, so not "reuse")
+
+- `caty.push_image(path, …)` for PC-local files: needs a new authenticated PC → phone fetch route (e.g. `GET /push-asset/<id>` with a short TTL) plus staging; the phone then receives a `media` push whose URL points at that route. Note `media_type` has no `pdf` value today; PDF depends on the app's URL sniffing and must be confirmed on the phone side first.
+- `caty.say(text)`: needs a new push kind in `_do_push` with its own payload branch (the current validation is url/title-shaped and shared by both kinds) and a phone-side handler in wip-caty-talk; TTS stays on the phone by default (`tts_fish.synthesize` / `sanitize_for_tts` in `caty_gateway.py` are a later, PC-side option).
+- Richer `caty.status` (`paired`, phone presence, last turn): needs a dedicated gateway status route, because pairedness is not durable in `PairingStore`, `presence_state` is per-job in-process state behind `CATY_PRESENCE_MODE2`, and "last turn" only exists in `history_store` (which this add-on must not read, see non-goals).
 
 ## Transport and boundary
 
 - **stdio only** in v1. No HTTP, no SSE, no listening port. The MCP process is spawned by the agent and dies with it.
-- **Same token boundary as pairing.** The MCP server authenticates to the gateway with the member's `CATY_TOKEN`, sent as `Authorization: Bearer` exactly like `caty-gateway push`. There is no new secret, no new credential file, and no token ever appears in a tool result or log line (`caty_push._redact`).
+- **Same token boundary as pairing.** The MCP server authenticates to the gateway with the member's `CATY_TOKEN`, sent as `Authorization: Bearer` exactly like `caty-gateway push`. There is no new secret, no new credential file, no admin token, and no token ever appears in a tool result or stderr line (`caty_push._redact` / `_error_message`).
 - Push kinds stay allow-listed in `_do_push`; the MCP layer cannot widen them.
-- The MCP server never reads the conversation history (`history_store.py`) and never calls the backends; it is one-directional, PC → phone.
+- The MCP server never reads the conversation history (`history_store.py`, `GET /history`), never touches `share_store`, and never calls the backends or `stream_pipeline`; it is one-directional, PC → phone.
 
-## Reuse points (actual symbols)
+## Reuse points (actual symbols, verified against main 8c67770)
 
-- `src/caty_gateway/cli.py` — `build_parser()`: add the `mcp` subparser (`--member`, `--gateway`, `--token-env`), dispatched with the same lazy-import pattern as `push`.
-- `src/caty_gateway/caty_push.py` — `send_event(args, token, kind, event_payload)`, `_redact`, `_error_message`, `parse_audience`: the HTTP client for `push_image` and `say`.
-- `src/caty_gateway/caty_gateway.py` — `_do_push` (kind allow-list, audience validation, `_require_write_auth`), `/health` handler, `_require_auth`.
-- `src/caty_gateway/push_events.py` — `PushEventQueue.publish_with_status` (event_key idempotency; `push_image` should pass an `event_key` derived from the file hash so a retried tool call does not duplicate the push).
-- `src/caty_gateway/share_store.py` — staging a local file so the phone can fetch it by URL (`ClaimedFile`, `sniff_attachment_mime`, `ShareQuotaExceeded`).
-- `src/caty_gateway/pairing_store.py` — `load_config` for `status.paired`; `src/caty_gateway/presence_state.py` — current phase for `status.presence`.
-- `src/caty_gateway/tts_fish.py` — `synthesize` / `sanitize_for_tts` (in `caty_gateway.py`) if `say` renders audio on the PC.
+- `src/caty_gateway/cli.py` — `build_parser()`: add the `mcp` subparser (`--member`, `--gateway`, `--token-env`).
+- `src/caty_gateway/caty_push.py` — `send_event(args, token, kind, event_payload)` (to be split into a request helper + CLI printer), `_redact`, `_error_message`, `parse_audience`.
+- `src/caty_gateway/caty_gateway.py` — `_do_push` (kind allow-list, url/title/media_type validation, `_require_write_auth`), `/health`, `/identity` (`identity_payload()`), `require_auth_enabled()`.
+- `src/caty_gateway/push_events.py` — `PushEventQueue.publish_with_status` (event_key semantics above).
+- `src/caty_gateway/pairing_store.py` — `PairingStore.live_count()`, `default_pairing_member()`, `default_pairing_root()` for `pending_pairings` / `member`.
 
 ## Non-goals
 
 - Replacing or bypassing the phone-initiated flow (`/v1/…` voice routes, `stream_pipeline`).
 - HTTP or SSE MCP transport, remote agents, multi-member fan-out.
 - Ollama / LM Studio integration (they are not MCP clients).
-- Any new credential, token scope, or admin-token use.
-- Reading history, injecting text into the phone conversation, or triggering a backend turn.
+- Any new credential, token scope, admin-token use, or listening port.
+- Reading history or shares, injecting text into the phone conversation, or triggering a backend turn.
 
-## Acceptance criteria (proposal for the implementation Issue)
+## Acceptance criteria (proposal for the v1 implementation Issue)
 
-1. `caty-gateway mcp --member <m>` starts, answers `initialize` and `tools/list` with exactly the three tools, and exits cleanly on stdin EOF.
-2. `caty.push_image` with a PNG and a PDF reaches the phone (real-device smoke, layer B of #2); a second call with the same file is a no-op via `event_key`.
-3. `caty.say` reaches the phone; text longer than 280 chars is rejected client-side with `ok:false`.
-4. `caty.status` reports `paired:false` before pairing and `paired:true` after, without a token in the output.
-5. Wrong or missing token → `ok:false` with the redacted gateway message; `grep` of the MCP process log shows no token.
-6. `make test` green with unit tests for the argument validation and the HTTP client (mocked gateway), `make lint gate env-check` green, `docs/env.md` regenerated if any env name is added.
-7. README gets one short section under the existing backends table ("Optional: use the phone from Claude Code / Codex via MCP").
+1. `caty-gateway mcp --member <m>` starts, answers `initialize` and `tools/list` with exactly `caty.push_image` and `caty.status`, writes nothing but JSON-RPC to stdout, and exits cleanly on stdin EOF.
+2. `caty.push_image` with a public PNG URL reaches the phone (real-device smoke, layer B of #2); a second identical call returns `duplicate:true`; a call with a changed title returns `ok:false` (409).
+3. `caty.push_image` with a `file://` URL, a local path, or a URL with userinfo is rejected client-side with `ok:false` before any HTTP call.
+4. `caty.status` returns `gateway_up:false` when the gateway is down, and `gateway_up:true` with `agent`, `identity.name`, `member`, `gateway_url` and an integer `pending_pairings` when it is up; no token in the output.
+5. Wrong or missing token → `ok:false` with the redacted gateway message; the MCP process's stderr contains no token.
+6. `make test` green with unit tests for argument validation, event_key derivation and the HTTP helper (mocked gateway); `make lint gate env-check` green; `docs/env.md` regenerated if any env name is added.
+7. README gets one short section under the existing backends table ("Optional: use the phone from Claude Code / Codex via MCP"), stating plainly that v1 pushes URLs, not local files.
 
 ## Estimate
 
-- `push_image` + `status` + CLI wiring + tests + README: **S–M** (one lane, `src/caty_gateway/cli.py`, new `src/caty_gateway/mcp_server.py`, `tests/test_mcp_server.py`, README).
-- `say`: **M** on its own, because it needs a new push kind in `_do_push` **and** a phone-side handler (wip-caty-talk), so it should be a second Issue after the first two tools ship.
-- Dependency: choose an MCP library or hand-roll JSON-RPC over stdio (the protocol surface for three tools is small; hand-rolling keeps the dependency list at zero, which matters for the one-line install).
+- v1 (`push_image` by URL + thin `status` + CLI wiring + tests + README): **S** — `src/caty_gateway/cli.py`, `src/caty_gateway/caty_push.py` (helper split), new `src/caty_gateway/mcp_server.py`, `tests/test_mcp_server.py`, README. Zero new dependencies if JSON-RPC over stdio is hand-rolled (two tools; keeps the one-line install unchanged).
+- phase 2, each its own Issue and each new server surface: local-file push route (**M**), `say` with phone handler (**M**, needs wip-caty-talk), richer status route (**S–M**).
 
-Release impact if implemented: new subcommand and new documented behaviour → **release ①** (minor bump, v0.2.0 candidate as #12 says).
+Release impact if v1 is implemented: new subcommand and new documented behaviour → **release ①** (minor bump, v0.2.0 candidate as #12 says).

--- a/docs/design/mcp-addon.md
+++ b/docs/design/mcp-addon.md
@@ -1,6 +1,6 @@
 # Design note — `caty-gateway mcp` (add-on, not scheduled)
 
-Status: design note for Issue #12, revision 2 (after a 3-seat review of r1). **No implementation until the owner says GO.** Size estimate at the end.
+Status: design note for Issue #12, revision 3 (r1 → 3-seat review → r2 → delta review → r3 wording fixes). **No implementation until the owner says GO.** Size estimate at the end.
 
 ## Purpose
 
@@ -22,11 +22,11 @@ Why MCP cannot be the core (recorded in #12): MCP servers are tool boxes the age
 | Tool | Arguments | Returns | Gateway path it reuses |
 |---|---|---|---|
 | `caty.push_image` | `url` (http/https, already reachable from the phone), `title` (≤200 chars; if omitted, the last path segment of the URL), `media_type` (`image` / `video` / `youtube`, optional), `session` (optional) | the gateway's own `POST /push` reply `{ok, id, duplicate, session_id, session_id_source}`, or `{ok:false, error}` with the redacted message | `POST /push` kind `media`, handled by `_do_push` in `caty_gateway.py` (allow-list `open_url` / `media`, `url` must be http(s) without userinfo, `title` required, `media_type` optional), auth via `_require_write_auth`; audience = the member |
-| `caty.status` | none | `{gateway_up, agent, identity, member, gateway_url, pending_pairings}` | `GET /health` → `{ok, agent}` (auth-gated when `require_auth_enabled()`); `GET /identity` → `identity_payload()` (id, name, accent colour, voice engine); `PairingStore.live_count()` from `pairing_store.py` = number of **unclaimed** QR credentials (a successful claim deletes the record and leaves a `consumed` tombstone, so the store does not say "paired: yes") |
+| `caty.status` | none | `{gateway_up, agent, identity, member, gateway_url, pending_pairings}` | `GET /health` → `{ok, agent}` (auth-gated only when `require_auth_enabled()`); `GET /identity` → `identity_payload()` (id, name, accent colour, voice engine; always behind `_require_auth`, which the client satisfies with `CATY_TOKEN`); `PairingStore.live_count()` from `pairing_store.py` = number of **unclaimed** QR credentials (a successful claim deletes the record and leaves a `consumed` tombstone, so the store does not say "paired: yes") |
 
 `push_image` in v1 therefore does what `caty-gateway push media` does today, from inside the agent, and nothing more. Local file paths are **not** accepted in v1: `share_store.py` is session-bound, single-use staging for **app → agent** shares (`POST /share`, consumed by the voice turn), and the gateway has no route that serves a PC-local file to the phone. Adding one is new server surface (phase 2).
 
-Idempotency: `PushEventQueue.publish_with_status` treats an `event_key` as a no-op only when kind, payload and audience are identical; a different payload under the same key is a 409 `event_key conflict`. The tool derives `event_key` from `sha256(url + title + media_type)` and sends exactly that payload, so a retried call is a no-op and a changed title is a conflict, which is surfaced as `ok:false`.
+Idempotency: `PushEventQueue.publish_with_status` treats an `event_key` as a no-op only when kind, payload and audience are identical; the same key with a different payload is a 409 `event_key conflict`. The tool derives `event_key` from the sha256 of the canonical JSON of the payload it actually POSTs (sorted keys; `media_type` absent when omitted, never the string `None`), so a retried identical call returns `duplicate:true`, and a call with a changed title is simply a new push (new key, `duplicate:false`). A 409 can therefore only come from a key collision with an event published by another producer, and is surfaced as `ok:false`.
 
 ### phase 2 (separate Issues; each is new gateway surface, so not "reuse")
 
@@ -60,7 +60,7 @@ Idempotency: `PushEventQueue.publish_with_status` treats an `event_key` as a no-
 ## Acceptance criteria (proposal for the v1 implementation Issue)
 
 1. `caty-gateway mcp --member <m>` starts, answers `initialize` and `tools/list` with exactly `caty.push_image` and `caty.status`, writes nothing but JSON-RPC to stdout, and exits cleanly on stdin EOF.
-2. `caty.push_image` with a public PNG URL reaches the phone (real-device smoke, layer B of #2); a second identical call returns `duplicate:true`; a call with a changed title returns `ok:false` (409).
+2. `caty.push_image` with a public PNG URL reaches the phone (real-device smoke, layer B of #2); a second identical call returns `duplicate:true`; a call with a changed title is a new push (`duplicate:false`).
 3. `caty.push_image` with a `file://` URL, a local path, or a URL with userinfo is rejected client-side with `ok:false` before any HTTP call.
 4. `caty.status` returns `gateway_up:false` when the gateway is down, and `gateway_up:true` with `agent`, `identity.name`, `member`, `gateway_url` and an integer `pending_pairings` when it is up; no token in the output.
 5. Wrong or missing token → `ok:false` with the redacted gateway message; the MCP process's stderr contains no token.

--- a/docs/design/mcp-addon.md
+++ b/docs/design/mcp-addon.md
@@ -1,0 +1,68 @@
+# Design note — `caty-gateway mcp` (add-on, not scheduled)
+
+Status: design note for Issue #12. **No implementation until the owner says GO.** Size estimate at the end.
+
+## Purpose
+
+Let an agent that is already running on the PC (Claude Code, Codex CLI) reach the paired CatyPhone from inside its session: send an image or PDF to the phone, speak a short status line, or ask whether the phone is paired and present. This is an add-on next to the core, in the same spirit as the avatar engine (design Q9): the phone-initiated voice flow stays exactly as it is, and an MCP server is never the way the phone reaches the agent.
+
+Why MCP cannot be the core (recorded in #12): MCP servers are tool boxes the agent calls. They cannot start a conversation when the phone speaks, and Ollama / LM Studio are not MCP clients.
+
+## Shape
+
+- New subcommand `caty-gateway mcp`, registered in `build_parser()` in `src/caty_gateway/cli.py` next to `push` and `doctor`.
+- The subcommand runs a stdio MCP server. It is a thin client of the running gateway: every tool call becomes an HTTP request to the local gateway, the same way `caty-gateway push` does today. The MCP process holds no state and opens no listening socket.
+- The agent's MCP config points at the command (`caty-gateway mcp --member <name>`), so the token and the gateway URL are resolved the way `qr --member` already resolves the installed service environment.
+
+## Tools (v1: exactly three)
+
+| Tool | Arguments | Returns | Gateway path it reuses |
+|---|---|---|---|
+| `caty.push_image` | `path` (local file, image or PDF), `caption` (string, optional), `session` (optional) | `{ok, share_id, event_key}` or `{ok:false, error}` | file → share store (`share_store.py`), then `caty_push.send_event(args, token, "media", payload)` → `POST /push` handled by `_do_push` in `caty_gateway.py` (kind `media`, audience = the member) |
+| `caty.say` | `text` (≤ 280 chars), `session` (optional) | `{ok, event_key}` or `{ok:false, error}` | **needs a new push kind `say`** in `_do_push` (today only `open_url` and `media` are accepted) and a matching handler on the phone; TTS itself stays on the phone side or reuses `tts_fish.synthesize` on the PC, to be decided in the implementation Issue |
+| `caty.status` | none | `{paired, member, presence, last_turn_at, gateway_url}` | `GET /health` (auth-gated when `require_auth_enabled()`), pairing state from `pairing_store.load_config`, presence from `presence_state` |
+
+Every tool returns a JSON object; failures are returned as `ok:false` with the same redacted message `caty_push._error_message` produces today (token never echoed).
+
+## Transport and boundary
+
+- **stdio only** in v1. No HTTP, no SSE, no listening port. The MCP process is spawned by the agent and dies with it.
+- **Same token boundary as pairing.** The MCP server authenticates to the gateway with the member's `CATY_TOKEN`, sent as `Authorization: Bearer` exactly like `caty-gateway push`. There is no new secret, no new credential file, and no token ever appears in a tool result or log line (`caty_push._redact`).
+- Push kinds stay allow-listed in `_do_push`; the MCP layer cannot widen them.
+- The MCP server never reads the conversation history (`history_store.py`) and never calls the backends; it is one-directional, PC → phone.
+
+## Reuse points (actual symbols)
+
+- `src/caty_gateway/cli.py` — `build_parser()`: add the `mcp` subparser (`--member`, `--gateway`, `--token-env`), dispatched with the same lazy-import pattern as `push`.
+- `src/caty_gateway/caty_push.py` — `send_event(args, token, kind, event_payload)`, `_redact`, `_error_message`, `parse_audience`: the HTTP client for `push_image` and `say`.
+- `src/caty_gateway/caty_gateway.py` — `_do_push` (kind allow-list, audience validation, `_require_write_auth`), `/health` handler, `_require_auth`.
+- `src/caty_gateway/push_events.py` — `PushEventQueue.publish_with_status` (event_key idempotency; `push_image` should pass an `event_key` derived from the file hash so a retried tool call does not duplicate the push).
+- `src/caty_gateway/share_store.py` — staging a local file so the phone can fetch it by URL (`ClaimedFile`, `sniff_attachment_mime`, `ShareQuotaExceeded`).
+- `src/caty_gateway/pairing_store.py` — `load_config` for `status.paired`; `src/caty_gateway/presence_state.py` — current phase for `status.presence`.
+- `src/caty_gateway/tts_fish.py` — `synthesize` / `sanitize_for_tts` (in `caty_gateway.py`) if `say` renders audio on the PC.
+
+## Non-goals
+
+- Replacing or bypassing the phone-initiated flow (`/v1/…` voice routes, `stream_pipeline`).
+- HTTP or SSE MCP transport, remote agents, multi-member fan-out.
+- Ollama / LM Studio integration (they are not MCP clients).
+- Any new credential, token scope, or admin-token use.
+- Reading history, injecting text into the phone conversation, or triggering a backend turn.
+
+## Acceptance criteria (proposal for the implementation Issue)
+
+1. `caty-gateway mcp --member <m>` starts, answers `initialize` and `tools/list` with exactly the three tools, and exits cleanly on stdin EOF.
+2. `caty.push_image` with a PNG and a PDF reaches the phone (real-device smoke, layer B of #2); a second call with the same file is a no-op via `event_key`.
+3. `caty.say` reaches the phone; text longer than 280 chars is rejected client-side with `ok:false`.
+4. `caty.status` reports `paired:false` before pairing and `paired:true` after, without a token in the output.
+5. Wrong or missing token → `ok:false` with the redacted gateway message; `grep` of the MCP process log shows no token.
+6. `make test` green with unit tests for the argument validation and the HTTP client (mocked gateway), `make lint gate env-check` green, `docs/env.md` regenerated if any env name is added.
+7. README gets one short section under the existing backends table ("Optional: use the phone from Claude Code / Codex via MCP").
+
+## Estimate
+
+- `push_image` + `status` + CLI wiring + tests + README: **S–M** (one lane, `src/caty_gateway/cli.py`, new `src/caty_gateway/mcp_server.py`, `tests/test_mcp_server.py`, README).
+- `say`: **M** on its own, because it needs a new push kind in `_do_push` **and** a phone-side handler (wip-caty-talk), so it should be a second Issue after the first two tools ship.
+- Dependency: choose an MCP library or hand-roll JSON-RPC over stdio (the protocol surface for three tools is small; hand-rolling keeps the dependency list at zero, which matters for the one-line install).
+
+Release impact if implemented: new subcommand and new documented behaviour → **release ①** (minor bump, v0.2.0 candidate as #12 says).


### PR DESCRIPTION
Design note for #12 (size S, docs only). **Draft on purpose — waiting for the owner's GO on the note. No implementation in this PR, and none is planned until GO.** Refs #12 (does not close it).

## What changed

- `docs/design/mcp-addon.md` (new, 75 lines, English), revision 3: purpose (an add-on that lets a running Claude Code / Codex session reach the paired phone; the core is not replaced), **v1 = two tools** (`caty.push_image` by URL = what `caty-gateway push media` does today, and a thin `caty.status` from `/health` + `/identity` + `PairingStore.live_count()`), transport (stdio only, stdout reserved for JSON-RPC), token boundary (same `CATY_TOKEN` bearer as `caty-gateway push`, zero new secret surface), reuse points named by real symbols in `src/caty_gateway/` and verified by three seats, non-goals, acceptance criteria, and an estimate (v1 = S).
- **Phase 2, each its own Issue and each new server surface**: local-file push (needs a new authenticated PC → phone fetch route, M), `say` (new push kind + phone-side handler in wip-caty-talk, M), richer status route (`paired` / presence / last turn, S–M).

## Why

Issue #12 asks for "design note (S) → owner GO → implementation". This is the note. Its main result is a correction to the idea as filed: of the three candidate tools, only *push by URL* and *liveness status* are genuine reuse. `push_image(path)` and `say` both need new gateway surface, because `share_store` is app → agent staging with no PC → phone fetch route, and `_do_push` only knows `open_url` / `media` with url+title validation.

## Files touched (declared set = diff)

`docs/design/mcp-addon.md` — 1 file, +75. Non-overlapping with PR #32 (#28).

## 完了記録 (Completion record)

candidate SHA: f34353f (= r1 c1f2d90 → r2 32897ca after the 3-seat review → r3 wording fixes from the delta review)
implementer: Alpha (Claude Code / Fable 5.1) — direct edit (docs); reuse points measured with Serena / grep against main 8c67770
reviewer r1 (c1f2d90): Grok 4.6 NO-GO (2 CRITICAL, 2 MAJOR, 1 MINOR, 1 NIT) / Kimi K3 NO-GO (2 MAJOR, 2 MINOR, 1 NIT) / Gemini 3.8 Flash NO-GO (1 MAJOR, 1 MINOR, 1 NIT) — **all three converged independently on the same two false maps** (share_store is app→agent, no PC→phone route; `/health` + `pairing_store.load_config` + `presence_state` cannot back `paired` / `presence` / `last_turn_at`) plus "v1 says three tools but the estimate defers `say`"
reviewer r2 delta (32897ca): Grok 4.6 GO-WITH-MINOR (all r1 findings RESOLVED except event_key PARTIAL; 2 new MINOR: key formula vs 409 wording, `media_type=None` concatenation) / Kimi K3 GO (all RESOLVED; 1 NIT: `/identity` is always authed) / Gemini 3.8 Flash GO (all RESOLVED, no new findings)
r3 (f34353f): the two Grok MINORs and the Kimi NIT adopted as wording (event_key = sha256 of canonical payload JSON; changed title = new push; `/identity` behind `_require_auth`). Wording only, not re-sent to the seats.
identity check: 別モデル（writer = Fable 5.1; seats per `loom-seats --size S --absent glm-5.3 --absent opus-5` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`; GLM 5.3 absent with 429 quota until 2026-09-10; opus-5 excluded as same family as the writer）
CI: at f34353f — see https://github.com/caty-ai/caty-gateway/pull/33/checks (docs-only; `scrub` 0 findings, `gate` OK, `env-check` no drift, `lint` OK locally)
release: N/A（③ 設計ノートのみ — nothing shipped changes）
previous release: v0.1.4 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.4（履行済み）

### Done when (#12 "Next": design note (S) → owner GO) → 結果

| 項目 | 結果 | 証拠 |
|---|---|---|
| Design note S, no implementation | DONE | one markdown file, no `src/` / README / workflow change; 3 seats F1 PASS |
| Same token boundary, stdio only, does not replace the phone-initiated flow | PASS | 3 seats F3 / F5 PASS at r1 and r2 |
| Cited symbols are real and correctly described | PASS at r2/r3 | r1 FAIL ×3 (F2) → r2 RESOLVED by all three seats against the worktree |
| Owner GO | **PENDING** | this PR stays draft; `ball:human` |

### Owner decision requested

- **GO** → Alpha opens the v1 implementation Issue (push_image by URL + status, S, release ①) and phase-2 Issues as placeholders; this PR is marked ready and merges as the design record.
- **NO-GO / changes** → comment on #12; this PR is amended or closed.

## Not in this lane

Implementation of any tool, `src/` changes, wip-caty-talk changes, #28 (PR #32), #2 smoke, #4 owner items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
