### PR TITLE
smoke: phone-less layer A — phone-sim client, e2e test, docs/smoke + first real-host records (#31)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python3
 
-.PHONY: test lint env-check scrub gate build
+.PHONY: test lint env-check scrub gate build smoke-a
 
 test:
 	@tmp=$$(mktemp) || exit 2; trap 'rm -f "$$tmp"' 0; \
@@ -29,3 +29,6 @@ gate:
 
 build:
 	uv build
+
+smoke-a:
+	$(PYTHON) -B tools/smoke/phone-sim.py $(SMOKE_ARGS)

--- a/docs/smoke/README.md
+++ b/docs/smoke/README.md
@@ -1,0 +1,204 @@
+# Smoke tests: layer A without a phone
+
+This is the phone-less smoke procedure for #31, a child of #2. Run from a
+checkout containing `tools/smoke/phone-sim.py`; the gateway itself should be a
+clean installation on the route's test host. Alpha records the actual run;
+this directory's README is a procedure, not evidence that a route has passed.
+
+The seven steps from design §4-3 are:
+
+1. Clean install and record the installed version.
+2. Run `doctor --backend <b>` until every check is PASS.
+3. Run `setup --member smoke-<route> --backend <b>` and issue the QR.
+4. Claim the pairing credential.
+5. Complete two conversation turns.
+6. Restart the service and complete a third turn in the same conversation.
+7. Check that neither token nor pairing secret appears in logs.
+
+| Layer | Owner and scope |
+|---|---|
+| A: this tool | Alpha, without a phone: clean install → doctor all PASS → setup → scripted pair claim → two text turns → service restart → third text turn (resume) → token/pair absent from logs |
+| B: phone | Owner: scan `caty-gateway qr --member <id>`, complete one spoken turn, then resume after a restart |
+
+Layer A does **not** prove QR rendering/scanning, audio/STT/TTS quality, or iOS
+client behaviour. A completed backend reply with `degraded: "tts"` passes A.
+
+## Prepare each route
+
+Follow [Engineering: Quick Start](../engineering.md#quick-start) for prerequisites:
+Python 3.10+, ffmpeg/ffprobe, logged-in Tailscale, and the backend's authenticated
+CLI or running HTTP server. Use a fresh test installation/profile; do not remove
+an existing user's service or history to make it clean. Install with
+`uv tool install caty-gateway` (or `pipx install caty-gateway`) and record
+`uv tool list` (or `pip show caty-gateway` in the installation's environment).
+The installer URL in Engineering is marked as awaiting the PyPI release; if the
+package is unavailable, record that blocker instead of claiming a clean install.
+
+Run one route at a time, or supply distinct `--port N` values to setup. Replace
+angle-bracket placeholders before executing. Keep backend secrets in a protected
+0600 environment file and load them into the shell before doctor/setup; do not
+put secret values in command arguments or copy them into a smoke record.
+
+### Claude
+
+Authenticate the `claude` CLI first.
+
+```sh
+caty-gateway doctor --backend claude
+caty-gateway setup --member smoke-claude --backend claude
+```
+
+### Codex
+
+Authenticate the `codex` CLI first.
+
+```sh
+caty-gateway doctor --backend codex
+caty-gateway setup --member smoke-codex --backend codex
+```
+
+### OpenClaw
+
+Configure the `openclaw` CLI and its agent first.
+
+```sh
+caty-gateway doctor --backend openclaw
+caty-gateway setup --member smoke-openclaw --backend openclaw
+```
+
+### Hermes
+
+Start Hermes' `/v1/responses` service and load `CATY_HERMES_API_KEY` from your
+protected environment file. Set `CATY_HERMES_URL` there if it is not the default
+`http://127.0.0.1:8642`.
+
+```sh
+caty-gateway doctor --backend hermes
+caty-gateway setup --member smoke-hermes --backend hermes
+```
+
+### Ollama via openai-compat
+
+Start Ollama and select an installed model returned by its `/v1/models` endpoint.
+
+```sh
+export CATY_OPENAI_BASE_URL=http://127.0.0.1:11434/v1
+export CATY_OPENAI_MODEL='<installed-model-id>'
+caty-gateway doctor --backend openai-compat
+caty-gateway setup --member smoke-ollama --backend openai-compat
+```
+
+### LM Studio via openai-compat
+
+Start LM Studio's local server and select a model returned by `/v1/models`.
+Use its configured port if it differs from 1234.
+
+```sh
+export CATY_OPENAI_BASE_URL=http://127.0.0.1:1234/v1
+export CATY_OPENAI_MODEL='<loaded-model-id>'
+caty-gateway doctor --backend openai-compat
+caty-gateway setup --member smoke-lm-studio --backend openai-compat
+```
+
+## Run phone-sim
+
+Use the route's member id below. Keep history enabled (do not use setup's
+`--no-history`). The tool self-issues with authenticated `/pair/new`, then makes
+exactly one `/pair/claim` attempt. Issuance replaces any existing live credential;
+do not reissue a QR concurrently. Claim must originate from loopback or the
+Tailscale tailnet, including the IPv6 ULA allowed by the
+[pairing contract](../contracts/pairing-v1.md).
+
+### Same host: Linux
+
+```sh
+python3 -B tools/smoke/phone-sim.py \
+  --env-file "$HOME/.config/caty-gateway/<id>.env" \
+  --restart-cmd 'systemctl --user restart caty-gateway-<id>' \
+  --log-cmd 'journalctl --user -u caty-gateway-<id> --no-pager' \
+  --require-recall --require-restart-observed --require-log-check \
+  --label '<route>@<host>'
+```
+
+### Same host: macOS
+
+macOS stores the member environment in the 0600 launchd plist, **not** a Linux
+`.env` file. This captured command converts only the two needed keys to env text.
+Do not run the inner extraction command separately: its output is confidential.
+
+```sh
+python3 -B tools/smoke/phone-sim.py \
+  --env-cmd "python3 -c 'import pathlib,plistlib,shlex; p=pathlib.Path.home()/\"Library/LaunchAgents/ai.caty.gateway.<id>.plist\"; e=plistlib.loads(p.read_bytes())[\"EnvironmentVariables\"]; print(\"\\n\".join(k+\"=\"+shlex.quote(e[k]) for k in (\"CATY_TOKEN\",\"CATY_PUBLIC_URL\")))'" \
+  --restart-cmd 'launchctl kickstart -k gui/$(id -u)/ai.caty.gateway.<id>' \
+  --log-file "$HOME/Library/Logs/caty-gateway-<id>.log" \
+  --require-recall --require-restart-observed --require-log-check \
+  --label '<route>@<host>'
+```
+
+### Another tailnet host: Linux gateway
+
+SSH must already work without an interactive prompt. The gateway's configured
+public URL must be reachable from the host running phone-sim. The inner quotes
+keep `~` from expanding on the local host before SSH sends the command.
+
+```sh
+python3 -B tools/smoke/phone-sim.py \
+  --env-cmd "ssh <host> cat '~/.config/caty-gateway/<id>.env'" \
+  --restart-cmd "ssh <host> systemctl --user restart caty-gateway-<id>" \
+  --log-cmd "ssh <host> journalctl --user -u caty-gateway-<id> --no-pager" \
+  --require-recall --require-restart-observed --require-log-check \
+  --label '<route>@<host>'
+```
+
+The restart commands and log locations above match
+[Engineering: Service operation](../engineering.md#service). History normally
+lives at `~/.local/state/caty-gateway/history/<id>/`; pairing state lives at
+`~/.local/state/caty-gateway/pairing/<member>/`. See
+[Storage locations](../engineering.md#storage-locations) for the other paths.
+For layer B, reissue with `caty-gateway qr --member <id>`; the QR CLI loads the
+installed environment and does not print the plaintext payload. If you already
+have a securely stored payload, `--qr-json <path>` (or `--qr-json -` for stdin)
+is an alternative to either env source.
+
+Exactly three turns run, with one session id. The last asks for the first turn's
+codeword. Read `resume_recall` as a recall probe, not proof of all history content.
+`restart.observed: false` means no health outage was seen; it is a warning unless
+`--require-restart-observed` is set. `--no-restart` reports a skipped restart and
+cannot establish restart/resume. No log source means `log_check: "skipped"`;
+`--require-log-check` makes that fatal. Log files and commands are repeatable.
+
+The final stdout is one JSON line; progress goes to stderr. Exit 0 means the
+selected checks passed. Save only that redacted summary in the record, never
+credentials, env output, or matching log lines. `make smoke-a SMOKE_ARGS='…'`
+also invokes the tool. Alpha writes a per-route record after the real run.
+
+## Record template
+
+```markdown
+---
+route: <claude|codex|openclaw|hermes|ollama|lm-studio>
+backend: <--backend value>
+host: <hostname or role>
+os: <macOS 15.x | Ubuntu 24.04 ...>
+date: <YYYY-MM-DD>
+layer: A
+caty_gateway_version: <pip show / uv tool list>
+result: PASS | FAIL | PARTIAL
+---
+## Steps
+| # | step | result | terminal value |
+|---|---|---|---|
+| 1 | clean install | | <command + version> |
+| 2 | doctor all PASS | | <PASS count> |
+| 3 | setup / QR issued | | <member id, port> |
+| 4 | pair claim (phone-sim) | | <http 200, latency> |
+| 5 | turns 1-2 | | <latency, degraded?> |
+| 6 | restart + turn 3 (resume) | | <downtime_s, resume_recall> |
+| 7 | token/pair not in logs | | <log source, pass> |
+## phone-sim summary
+<the one JSON line, verbatim (it contains no secrets)>
+## Findings
+- <bugs → Issue link, or "none">
+```
+
+Layer B checklist: the owner's per-route one-screen checklist is posted on #2.

--- a/docs/smoke/README.md
+++ b/docs/smoke/README.md
@@ -54,7 +54,7 @@ Authenticate the `claude` CLI first.
 
 ```sh
 caty-gateway doctor --backend claude
-caty-gateway setup --member smoke-claude --backend claude
+CATY_QR_DELIVERY=tty caty-gateway setup --member smoke-claude --backend claude --yes
 ```
 
 ### Codex
@@ -63,7 +63,7 @@ Authenticate the `codex` CLI first.
 
 ```sh
 caty-gateway doctor --backend codex
-caty-gateway setup --member smoke-codex --backend codex
+CATY_QR_DELIVERY=tty caty-gateway setup --member smoke-codex --backend codex --yes
 ```
 
 ### OpenClaw
@@ -72,7 +72,7 @@ Configure the `openclaw` CLI and its agent first.
 
 ```sh
 caty-gateway doctor --backend openclaw
-caty-gateway setup --member smoke-openclaw --backend openclaw
+CATY_QR_DELIVERY=tty caty-gateway setup --member smoke-openclaw --backend openclaw --yes
 ```
 
 ### Hermes
@@ -83,7 +83,7 @@ protected environment file. Set `CATY_HERMES_URL` there if it is not the default
 
 ```sh
 caty-gateway doctor --backend hermes
-caty-gateway setup --member smoke-hermes --backend hermes
+CATY_QR_DELIVERY=tty caty-gateway setup --member smoke-hermes --backend hermes --yes
 ```
 
 ### Ollama via openai-compat
@@ -94,7 +94,7 @@ Start Ollama and select an installed model returned by its `/v1/models` endpoint
 export CATY_OPENAI_BASE_URL=http://127.0.0.1:11434/v1
 export CATY_OPENAI_MODEL='<installed-model-id>'
 caty-gateway doctor --backend openai-compat
-caty-gateway setup --member smoke-ollama --backend openai-compat
+CATY_QR_DELIVERY=tty caty-gateway setup --member smoke-ollama --backend openai-compat --yes
 ```
 
 ### LM Studio via openai-compat
@@ -106,7 +106,7 @@ Use its configured port if it differs from 1234.
 export CATY_OPENAI_BASE_URL=http://127.0.0.1:1234/v1
 export CATY_OPENAI_MODEL='<loaded-model-id>'
 caty-gateway doctor --backend openai-compat
-caty-gateway setup --member smoke-lm-studio --backend openai-compat
+CATY_QR_DELIVERY=tty caty-gateway setup --member smoke-lm-studio --backend openai-compat --yes
 ```
 
 ## Run phone-sim
@@ -174,7 +174,7 @@ codeword. Read `resume_recall` as a recall probe, not proof of all history conte
 `restart.observed: false` means no health outage was seen; it is a warning unless
 `--require-restart-observed` is set. `--no-restart` reports a skipped restart and
 cannot establish restart/resume. No log source means `log_check: "skipped"`;
-`--require-log-check` makes that fatal. Log files and commands are repeatable.
+`--require-log-check` makes that fatal. Log files and commands are repeatable; `--log-timeout` sets each log command's timeout (default: 60 seconds).
 
 The final stdout is one JSON line; progress goes to stderr. Exit 0 means the
 selected checks passed. Save only that redacted summary in the record, never

--- a/docs/smoke/README.md
+++ b/docs/smoke/README.md
@@ -34,6 +34,15 @@ an existing user's service or history to make it clean. Install with
 The installer URL in Engineering is marked as awaiting the PyPI release; if the
 package is unavailable, record that blocker instead of claiming a clean install.
 
+When the host is driven over `ssh` (no TTY): `setup` asks `Run this plan? [y/N]`
+and exits unless `--yes` is given, and the default QR delivery (`auto`) picks the
+URL mode on a non-TTY, which blocks until the one-shot PNG is fetched or the
+credential expires. Run setup as
+`CATY_QR_DELIVERY=tty caty-gateway setup --member <id> --backend <b> --port N --yes`
+so the ASCII QR is printed and setup returns. Measured on 2026-09-06 (mac-mini
+records in this directory). Also export a `PATH` that contains the backend CLI
+before running setup: the service inherits the PATH of the shell that ran setup.
+
 Run one route at a time, or supply distinct `--port N` values to setup. Replace
 angle-bracket placeholders before executing. Keep backend secrets in a protected
 0600 environment file and load them into the shell before doctor/setup; do not

--- a/docs/smoke/claude-mac-mini-2026-09-06.md
+++ b/docs/smoke/claude-mac-mini-2026-09-06.md
@@ -1,0 +1,35 @@
+---
+route: claude
+backend: claude
+host: mac-mini (family Mac mini, not the dev machine; reached over Tailscale from the dev MBP)
+os: macOS 26.5.2 (arm64)
+date: 2026-09-06
+layer: A
+caty_gateway_version: caty-gateway 0.1.4 from PyPI (uv tool install --python 3.12 → Python 3.12.12), isolated prefix UV_TOOL_DIR=~/caty-smoke/uv-tools
+result: FAIL (step 5; environment — Claude Code CLI on the host is not logged in; steps 1-4 PASS)
+---
+
+Backend: Claude Code `2.1.220` at `~/.local/bin/claude` on the host. Member `smoke-claude`, port 18768. Same install prefix and tailnet layout as the Ollama record.
+
+## Steps
+
+| # | step | result | terminal value |
+|---|---|---|---|
+| 1 | clean install | PASS | shared with the Ollama record (same `uv tool install`, 0.1.4) |
+| 2 | doctor all PASS | PASS with 1 WARN | `doctor --backend claude --port 18768`: 13 PASS, 1 WARN `claude credentials: sign in with Claude CLI; credentials stored in the OS keychain cannot be checked passively`, 0 FAIL |
+| 3 | setup / QR issued | PASS | `setup --member smoke-claude --backend claude --port 18768 --yes` (`CATY_QR_DELIVERY=tty`) → `Setup complete`, label `ai.caty.gateway.smoke-claude`, redacted payload `{"v":1,"url":"http://100.88.190.89:18768","id":"smoke-claude","pair":"874e3bb5.[REDACTED]"}` |
+| 4 | pair claim (phone-sim) | PASS | HTTP 200, 0.020 s (`pair_id` ea366d13) |
+| 5 | turns 1-2 | FAIL | turn 1: `/talk2` 200, then `/reply/<id>` 500 after 1.1 s. Gateway log: `stage=stream status=error error_type=RuntimeError`, `backend=claude status=error gen=0.9s`. Reproduced on the host: `claude -p "Reply with just OK" --output-format json` → `is_error: true`, result `Not logged in · Please run /login` |
+| 6 | restart + turn 3 (resume) | not reached | — |
+| 7 | token/pair not in logs | not reached by phone-sim | manual check on the host: token-shaped grep over `~/Library/Logs/caty-gateway-smoke-claude.log` = 0 |
+
+## phone-sim summary
+
+```
+{"claim":{"http_status":200,"latency_s":0.02},"error":"reply failed (HTTP 500)","finished_at":"2026-09-06T17:09:01Z","gateway_url":"100.88.190.89:18768","label":"claude@mac-mini","layer":"A","log_check":"skipped","log_secret_leak":null,"member_id":"smoke-claude","ok":false,"pair_id":"ea366d13","restart":{"downtime_s":null,"observed":"skipped"},"resume_recall":null,"session_id":"smoke-20260906-e0f22d","stage":"turn1","stages":["qr","claim","turn1"],"started_at":"2026-09-06T17:08:59Z","turns":[{"degraded":null,"http_status":500,"latency_s":1.083,"n":1,"reply_chars":0,"reply_preview":""}],"warnings":[]}
+```
+
+## Findings
+
+- Not a gateway bug: the doctor WARN was the right signal (keychain credentials cannot be verified passively) and the first turn is where a missing login shows up. Owner action: `claude` → `/login` on the mini (or run this route on a host where Claude Code is signed in), then re-run the same phone-sim command; no reinstall needed. The service is left installed on the host.
+- The 1 WARN means step 2 was not literally "all PASS"; recorded as such rather than rounded up.

--- a/docs/smoke/codex-mac-mini-2026-09-06.md
+++ b/docs/smoke/codex-mac-mini-2026-09-06.md
@@ -1,0 +1,35 @@
+---
+route: codex
+backend: codex
+host: mac-mini (family Mac mini, not the dev machine; reached over Tailscale from the dev MBP)
+os: macOS 26.5.2 (arm64)
+date: 2026-09-06
+layer: A
+caty_gateway_version: caty-gateway 0.1.4 from PyPI (uv tool install --python 3.12 → Python 3.12.12), isolated prefix UV_TOOL_DIR=~/caty-smoke/uv-tools
+result: FAIL (step 5; environment — the host's Codex account had exhausted its usage limit; steps 1-4 PASS)
+---
+
+Backend: `codex-cli 0.144.6`, `codex login status` = "Logged in using ChatGPT" (the host user's own account). Member `smoke-codex`, port 18767. Same install prefix and the same tailnet layout as the Ollama record.
+
+## Steps
+
+| # | step | result | terminal value |
+|---|---|---|---|
+| 1 | clean install | PASS | shared with the Ollama record (same `uv tool install`, 0.1.4) |
+| 2 | doctor all PASS | PASS | `doctor --backend codex --port 18767`: all PASS (14), including `codex login` |
+| 3 | setup / QR issued | PASS | `setup --member smoke-codex --backend codex --port 18767 --yes` (`CATY_QR_DELIVERY=tty`) → `Setup complete`, label `ai.caty.gateway.smoke-codex`, redacted payload `{"v":1,"url":"http://100.88.190.89:18767","id":"smoke-codex","pair":"5b91a833.[REDACTED]"}` |
+| 4 | pair claim (phone-sim) | PASS | HTTP 200, 0.022 s (`pair_id` db94456f) |
+| 5 | turns 1-2 | FAIL | turn 1: `/talk2` 200, then `/reply/<id>` 500 after 9.1 s. Gateway log: `stage=stream status=error error_type=RuntimeError`, turn summary `backend=codex status=error gen=8.9s`. Reproduced on the host outside the gateway: `codex exec --skip-git-repo-check --json "Reply with just OK"` → `{"type":"error","message":"You've hit your usage limit. ... try again at 9:31 AM."}` |
+| 6 | restart + turn 3 (resume) | not reached | — |
+| 7 | token/pair not in logs | not reached by phone-sim (stops at the first fatal stage) | manual check on the host: `grep -cE '[0-9a-f]{8}\.[0-9a-f]{32}' ~/Library/Logs/caty-gateway-smoke-codex.log` = 0 |
+
+## phone-sim summary
+
+```
+{"claim":{"http_status":200,"latency_s":0.022},"error":"reply failed (HTTP 500)","finished_at":"2026-09-06T17:07:55Z","gateway_url":"100.88.190.89:18767","label":"codex@mac-mini","layer":"A","log_check":"skipped","log_secret_leak":null,"member_id":"smoke-codex","ok":false,"pair_id":"db94456f","restart":{"downtime_s":null,"observed":"skipped"},"resume_recall":null,"session_id":"smoke-20260906-3debfa","stage":"turn1","stages":["qr","claim","turn1"],"started_at":"2026-09-06T17:07:46Z","turns":[{"degraded":null,"http_status":500,"latency_s":9.091,"n":1,"reply_chars":0,"reply_preview":""}],"warnings":[]}
+```
+
+## Findings
+
+- Not a gateway bug: the backend refused the turn because the account's Codex quota was exhausted. `doctor` cannot see this (passive checks only, by design). The gateway surfaced it correctly as a 500 on `/reply/<id>` and did not leak anything into the log.
+- Re-run needed once the quota resets (the host said "try again at 9:31 AM" host time): same phone-sim command, no reinstall. The service is left installed on the host.

--- a/docs/smoke/hermes-hetzner-vps-2026-09-06.md
+++ b/docs/smoke/hermes-hetzner-vps-2026-09-06.md
@@ -1,0 +1,27 @@
+---
+route: hermes
+backend: hermes
+host: hetzner-vps (Linux VPS, Tailscale)
+os: unknown (not reached)
+date: 2026-09-06
+layer: A
+caty_gateway_version: not installed
+result: NOT RUN (host not reachable from the automated session; nothing was measured)
+---
+
+## Steps
+
+| # | step | result | terminal value |
+|---|---|---|---|
+| 1 | clean install | not attempted | The only SSH route available to the automation this session is a forced-command read key (`pgl-luca-dispatch: request rejected` for any shell); the operator route was not permitted from the automated session. No command ran on the host. |
+| 2-7 | — | not reached | — |
+
+## phone-sim summary
+
+Not run.
+
+## Findings
+
+- Nothing to report about the gateway. This route is blocked on host access, not on software.
+- What layer A needs on that host, once reachable: `uv tool install caty-gateway` into a private `UV_TOOL_DIR`, a Hermes `/v1/responses` endpoint plus `CATY_HERMES_API_KEY` that is *not* another household member's production instance, `loginctl enable-linger`, and then the "Another tailnet host: Linux gateway" command block in `README.md`.
+- Ollama was not checked on that host either (same reason).

--- a/docs/smoke/ollama-mac-mini-2026-09-06.md
+++ b/docs/smoke/ollama-mac-mini-2026-09-06.md
@@ -1,0 +1,38 @@
+---
+route: ollama
+backend: openai-compat
+host: mac-mini (family Mac mini, not the dev machine; reached over Tailscale from the dev MBP)
+os: macOS 26.5.2 (arm64)
+date: 2026-09-06
+layer: A
+caty_gateway_version: caty-gateway 0.1.4 from PyPI (uv tool install --python 3.12 → Python 3.12.12), isolated prefix UV_TOOL_DIR=~/caty-smoke/uv-tools
+result: PASS
+---
+
+Backend: Ollama 0.18.2 already running on the host (`brew services`), model `huihui_ai/granite3.2-vision-abliterated:latest` (the only model pulled there). `CATY_OPENAI_BASE_URL=http://127.0.0.1:11434/v1`. Member `smoke-ollama`, port 18766 (the default port was taken by the host's existing gateway; `doctor` reported it and `--port` fixed it).
+
+phone-sim ran on the dev MBP (tailnet 100.104.116.34) against the gateway's public URL on the mini (tailnet 100.88.190.89:18766); the env read, the restart and the log read went over `ssh mac-mini`. Claim therefore came from a tailnet peer, as a phone would.
+
+## Steps
+
+| # | step | result | terminal value |
+|---|---|---|---|
+| 1 | clean install | PASS | `uv tool install --python 3.12 caty-gateway` → `caty-gateway==0.1.4`, `qrcode==8.2`, `pillow==12.3.0`; `caty-gateway --help` OK |
+| 2 | doctor all PASS | PASS | `doctor --backend openai-compat --port 18766`: 14 PASS, 0 FAIL (without `--port`: 1 FAIL `port`, default port already listening on this host) |
+| 3 | setup / QR issued | PASS | `setup --member smoke-ollama --backend openai-compat --port 18766 --yes` with `CATY_QR_DELIVERY=tty` (ssh session) → `Setup complete`, launchd label `ai.caty.gateway.smoke-ollama`, ASCII QR shown, redacted payload `{"v":1,"url":"http://100.88.190.89:18766","id":"smoke-ollama","pair":"9c772d2d.[REDACTED]"}` |
+| 4 | pair claim (phone-sim) | PASS | self-issue via `/pair/new` then one `/pair/claim` from the tailnet: HTTP 200, 0.018 s (`pair_id` e8beb29f; the setup-time credential 9c772d2d was replaced by the new issue, as the contract says) |
+| 5 | turns 1-2 | PASS | turn 1: 200 in 19.9 s (model cold load), reply `OK`; turn 2: 200 in 2.9 s; `degraded: null` (TTS produced audio) |
+| 6 | restart + turn 3 (resume) | PASS | `launchctl kickstart -k gui/501/ai.caty.gateway.smoke-ollama`: outage observed, `downtime_s` 0.545; turn 3: 200 in 2.9 s, `resume_recall: true` (the codeword from turn 1 came back after the restart, i.e. the on-disk history was replayed) |
+| 7 | token/pair not in logs | PASS | `--log-cmd "ssh mac-mini cat ~/Library/Logs/caty-gateway-smoke-ollama.log"` → `log_check: pass`; independent check on the host: `grep -cE '[0-9a-f]{8}\.[0-9a-f]{32}'` over the 36-line log = 0 |
+
+## phone-sim summary
+
+```
+{"claim":{"http_status":200,"latency_s":0.018},"error":null,"finished_at":"2026-09-06T17:06:36Z","gateway_url":"100.88.190.89:18766","label":"ollama@mac-mini","layer":"A","log_check":"pass","log_secret_leak":false,"member_id":"smoke-ollama","ok":true,"pair_id":"e8beb29f","restart":{"downtime_s":0.545,"observed":true},"resume_recall":true,"session_id":"smoke-20260906-9f107b","stage":"done","stages":["qr","claim","turn1","turn2","restart","turn3","logcheck","done"],"started_at":"2026-09-06T17:06:09Z","turns":[{"degraded":null,"http_status":200,"latency_s":19.935,"n":1,"reply_chars":3,"reply_preview":"\nOK"},{"degraded":null,"http_status":200,"latency_s":2.858,"n":2,"reply_chars":13,"reply_preview":"\n了解我可以帮助你做什么？"},{"degraded":null,"http_status":200,"latency_s":2.854,"n":3,"reply_chars":17,"reply_preview":"\n blue-d1326c\n\n<|"}],"warnings":[]}
+```
+
+## Findings
+
+- Gateway: none blocking. Two observations reported on #2 for separate S Issues: (a) `setup` is interactive by default and needs `--yes` when stdin is not a TTY, which the Quick Start does not say; (b) `status --member` keeps the `Detail:` line of an earlier failed attempt after a later successful run.
+- Backend quirks, not gateway: turn 2 came back in Chinese (model behaviour); turn 3 reply carried a `<|` token fragment from the model.
+- Service left installed on the host for layer B (`caty-gateway qr --member smoke-ollama` on the mini; `PATH` must include `~/caty-smoke/bin`).

--- a/docs/smoke/openclaw-mac-mini-2026-09-06.md
+++ b/docs/smoke/openclaw-mac-mini-2026-09-06.md
@@ -1,0 +1,27 @@
+---
+route: openclaw
+backend: openclaw
+host: mac-mini (family Mac mini)
+os: macOS 26.5.2 (arm64)
+date: 2026-09-06
+layer: A
+caty_gateway_version: caty-gateway 0.1.4 from PyPI (same isolated prefix as the other mac-mini records)
+result: NOT RUN (stopped at step 2; the host no longer runs an OpenClaw gateway)
+---
+
+## Steps
+
+| # | step | result | terminal value |
+|---|---|---|---|
+| 1 | clean install | PASS | shared with the Ollama record |
+| 2 | doctor all PASS | FAIL | `doctor --backend openclaw`: `openclaw agents` PASS, `openclaw agent` PASS, `openclaw gateway token` PASS, **`openclaw gateway` FAIL** (`start the gateway and set CATY_GATEWAY_URL to its reachable HTTP URL`). `~/.openclaw/openclaw.json` still says port 18789, but nothing listens there and `launchctl list` has no `ai.openclaw.gateway` job: the household's OpenClaw agent on this host was migrated to Hermes (`ai.hermes.gateway-caty` is what runs now). |
+| 3-7 | — | not reached | starting someone else's production OpenClaw gateway is outside this smoke |
+
+## phone-sim summary
+
+Not run.
+
+## Findings
+
+- No gateway defect. `doctor` identified the missing OpenClaw gateway precisely.
+- This route needs a host that actually runs OpenClaw (the #2 table assumed the Mac mini; that assumption is now stale). Candidates: a fresh OpenClaw install on the dev MBP second user, or another family host that still runs OpenClaw. Listed on #2.

--- a/tests/test_phone_sim.py
+++ b/tests/test_phone_sim.py
@@ -1,0 +1,432 @@
+"""Pure smoke-client checks; test_e2e_* requires real loopback sockets."""
+
+import contextlib
+import http.client
+import http.server
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "smoke" / "phone-sim.py"
+SPEC = importlib.util.spec_from_file_location("phone_sim", SCRIPT)
+phone_sim = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = phone_sim
+SPEC.loader.exec_module(phone_sim)
+
+
+def _check(condition, message):
+    # Only booleans enter assertion rewriting: never show credential operands.
+    assert condition, message
+
+
+def _credentials():
+    return {"pair": "1a2b3c4d." + "ab" * 16, "token": "client-" + secrets.token_hex(12)}
+
+
+def _payload():
+    return {"v": 1, "url": "http://127.0.0.1:8765", "pair": _credentials()["pair"], "id": "smoke"}
+
+
+def test_parse_env_export_quotes_comments_crlf():
+    value = "env-" + secrets.token_hex(12)
+    text = ' # comment\r\nexport CATY_TOKEN="' + value + '" # note\r\nCATY_PUBLIC_URL=\'http://localhost:8765\'\r\nOTHER="has # inside"\r\nPLAIN=word # comment\r\n'
+    result = phone_sim.parse_env_text(text)
+    _check(result.get("CATY_TOKEN") == value, "quoted token was not parsed")
+    assert result["CATY_PUBLIC_URL"] == "http://localhost:8765"
+    assert result["OTHER"] == "has # inside"
+    assert result["PLAIN"] == "word"
+
+
+def test_validate_qr_contract():
+    value = _payload()
+    _check(phone_sim.validate_qr_payload(value) == value, "contract payload rejected")
+
+
+@pytest.mark.parametrize("field,value", [
+    ("v", 2), ("v", True), ("v", "1"),
+    ("url", "http://user@localhost:8765"),
+    ("url", "http://localhost:8765?query=yes"),
+    ("url", "http://localhost:8765#fragment"),
+    ("url", "relative/path"), ("url", "ftp://localhost"),
+    ("pair", "invalid"), ("id", ""),
+])
+def test_validate_qr_rejects_without_secret_in_error(field, value):
+    payload = _payload()
+    secret_half = payload["pair"].split(".")[1]
+    payload[field] = value
+    try:
+        phone_sim.validate_qr_payload(payload)
+    except ValueError as error:
+        _check(secret_half not in str(error), "validation disclosed a secret")
+    else:
+        pytest.fail("invalid QR payload accepted")
+
+
+def test_redact_known_and_generic_secrets():
+    credentials = _credentials()
+    credentials["pair_secret"] = credentials["pair"].split(".")[1]
+    generic = "9f8e7d6c." + "cd" * 16
+    result = phone_sim.redact(" ".join(credentials.values()) + " " + generic, credentials)
+    _check(all(value not in result for value in credentials.values()), "known secret survived redaction")
+    _check(generic not in result and "cd" * 16 not in result, "generic pair survived redaction")
+    assert "[REDACTED]" in result
+
+
+@pytest.mark.parametrize("name", ["pair", "pair_secret", "token"])
+def test_find_leaks_returns_names_only(name):
+    credentials = _credentials()
+    credentials["pair_secret"] = credentials["pair"].split(".")[1]
+    result = phone_sim.find_leaks("log prefix " + credentials[name], credentials)
+    _check(name in result, "expected leak name absent")
+    _check(all(item in credentials for item in result), "leak detector returned a value")
+    _check(all(value not in str(result) for value in credentials.values()), "leak detector disclosed secret")
+
+
+def test_find_leaks_allows_public_pair_id():
+    credentials = _credentials()
+    credentials["pair_secret"] = credentials["pair"].split(".")[1]
+    assert phone_sim.find_leaks(credentials["pair"].split(".")[0], credentials) == []
+
+
+class _FakeOpenAI(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def _send(self, content_type, body):
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path != "/v1/models":
+            self.send_error(404)
+            return
+        self._send("application/json", json.dumps({"data": [{"id": "phone-sim-fake"}]}).encode())
+
+    def do_POST(self):
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        users = [message["content"] for message in request["messages"] if message["role"] == "user"]
+        reply = "OK (%d user messages so far)" % len(users)
+        if users and "What was the codeword" in users[-1]:
+            match = re.search(r"\bblue-[0-9a-f]{6}\b", "\n".join(users[:-1]))
+            reply = match.group(0) if match else "unknown"
+        if request.get("stream"):
+            chunks = [reply[:4], reply[4:]]
+            body = "".join("data: " + json.dumps({"choices": [{"delta": {"content": chunk}}]}) + "\n\n" for chunk in chunks)
+            self._send("text/event-stream", (body + "data: [DONE]\n\n").encode())
+        else:
+            self._send("application/json", json.dumps({"choices": [{"message": {"content": reply}}]}).encode())
+
+
+_SUPERVISOR = r'''
+import pathlib, signal, subprocess, sys, time
+root = pathlib.Path(sys.argv[1])
+child = None
+def stop(signum, frame):
+    (root / "stop").touch()
+    if child is not None and child.poll() is None:
+        child.terminate()
+signal.signal(signal.SIGTERM, stop)
+with (root / "gateway.log").open("ab", buffering=0) as log:
+    try:
+        while not (root / "stop").exists():
+            child = subprocess.Popen([sys.executable, "-B", "-m", "caty_gateway.caty_gateway"], stdout=log, stderr=log)
+            (root / "gateway.pid").write_text(str(child.pid))
+            child.wait()
+            (root / "gateway.pid").unlink(missing_ok=True)
+            time.sleep(1.5)
+    finally:
+        if child is not None and child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+'''
+
+
+def _health(port, token):
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=0.5)
+    try:
+        connection.request("GET", "/health", headers={"Authorization": "Bearer " + token})
+        response = connection.getresponse()
+        response.read()
+        return response.status == 200
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        connection.close()
+
+
+@contextlib.contextmanager
+def _running_gateway(tmp_path):
+    fake = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _FakeOpenAI)
+    thread = threading.Thread(target=fake.serve_forever, daemon=True)
+    thread.start()
+    supervisor = None
+    try:
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", 0))
+            port = listener.getsockname()[1]
+        token = "smoke-auth-" + secrets.token_hex(16)
+        home = tmp_path / "home"
+        home.mkdir()
+        env = {key: value for key, value in os.environ.items() if not key.startswith("CATY_")}
+        env.update({
+            "HOME": str(home), "CATY_AGENT": "phone-sim-fake", "CATY_ID": "smoke-e2e",
+            "CATY_BACKEND": "openai-compat", "CATY_GATEWAY_BIND": "127.0.0.1",
+            "CATY_GATEWAY_PORT": str(port), "CATY_PAIRING_DIR": str(tmp_path / "pairing"),
+            "CATY_PUBLIC_URL": "http://127.0.0.1:%d" % port,
+            "CATY_REQUIRE_AUTH": "1", "CATY_TOKEN": token, "PYTHONUNBUFFERED": "1",
+            "CATY_OPENAI_BASE_URL": "http://127.0.0.1:%d/v1" % fake.server_port,
+            "CATY_OPENAI_MODEL": "phone-sim-fake", "CATY_HISTORY_DIR": str(tmp_path / "history"),
+        })
+        envfile = tmp_path / "member.env"
+        envfile.touch(mode=0o600)
+        envfile.write_text("CATY_TOKEN=" + token + "\nCATY_PUBLIC_URL=" + env["CATY_PUBLIC_URL"] + "\n")
+        supervisor = subprocess.Popen([sys.executable, "-B", "-c", _SUPERVISOR, str(tmp_path)], env=env, cwd=ROOT, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        deadline = time.monotonic() + 60
+        while not _health(port, token):
+            if supervisor.poll() is not None or time.monotonic() >= deadline:
+                pytest.fail("gateway did not become ready; inspect the temporary gateway.log locally")
+            time.sleep(0.05)
+        yield envfile, token
+    finally:
+        (tmp_path / "stop").touch()
+        if supervisor is not None:
+            # The supervisor knows its owned child's Popen object and terminates it.
+            supervisor.terminate()
+            try:
+                supervisor.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pidfile = tmp_path / "gateway.pid"
+                if pidfile.exists():
+                    try:
+                        os.kill(int(pidfile.read_text()), signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                supervisor.kill()
+                supervisor.wait(timeout=5)
+        fake.shutdown()
+        fake.server_close()
+        thread.join(timeout=5)
+
+
+def _run_client(envfile, token, *args):
+    result = subprocess.run([sys.executable, "-B", str(SCRIPT), "--env-file", str(envfile), "--label", "e2e", *args], cwd=ROOT, capture_output=True, text=True, timeout=120)
+    output = result.stdout + result.stderr
+    _check(token not in output, "client disclosed the administrator token")
+    _check(re.search(r"[0-9a-f]{8}\.[0-9a-f]{32}", output) is None, "client disclosed a pairing credential")
+    _check(len(result.stdout.splitlines()) == 1, "client did not print exactly one JSON line")
+    try:
+        summary = json.loads(result.stdout)
+    except ValueError:
+        pytest.fail("client stdout was not JSON")
+    return result.returncode, summary
+
+
+def test_e2e_phone_sim_round_trip(tmp_path):
+    with _running_gateway(tmp_path) as (envfile, token):
+        pidfile = shlex.quote(str(tmp_path / "gateway.pid"))
+        # Wait until the old child is reaped; the supervisor pauses before respawn.
+        restart = 'pid=$(cat %s); kill -TERM "$pid"; while kill -0 "$pid" 2>/dev/null; do sleep 0.05; done' % pidfile
+        returncode, summary = _run_client(envfile, token, "--restart-cmd", restart, "--log-file", str(tmp_path / "gateway.log"), "--require-recall", "--require-restart-observed")
+        _check(returncode == 0, "round trip client failed")
+        assert summary["ok"] is True
+        assert summary["stage"] == "done"
+        assert len(summary["turns"]) == 3
+        assert all(turn["http_status"] == 200 for turn in summary["turns"])
+        assert summary["restart"]["observed"] is True
+        assert summary["resume_recall"] is True
+        assert summary["log_check"] == "pass"
+
+
+def test_e2e_phone_sim_detects_log_leak(tmp_path):
+    with _running_gateway(tmp_path) as (envfile, token):
+        leakfile = tmp_path / "leaky.log"
+        leakfile.write_text("deliberate negative control: " + token + "\n")
+        returncode, summary = _run_client(envfile, token, "--no-restart", "--log-file", str(leakfile))
+        _check(returncode == 1, "log leak did not fail the client")
+        assert summary["ok"] is False
+        assert summary["stage"] == "logcheck"
+        assert summary["log_check"] == "leak"
+        assert summary["log_secret_leak"] is True
+
+
+class _MockGateway:
+    """HTTP seam for the full client flow without opening sockets."""
+
+    def __init__(self, claim_status=200, health=(200,)):
+        self.credentials = _credentials()
+        self.credentials["CATY_TOKEN"] = "admin-" + secrets.token_hex(12)
+        self.credentials["pair_secret"] = self.credentials["pair"].split(".")[1]
+        self.payload = {**_payload(), "pair": self.credentials["pair"]}
+        self.calls = []
+        self.claim_status = claim_status
+        self.health = iter(health)
+        self.turn = 0
+        self.polls = {}
+        self.codeword = None
+
+    def request(self, url, method, path, *, token=None, headers=None, body=None, timeout=15):
+        self.calls.append((method, path))
+        if path == "/pair/new":
+            _check(token == self.credentials["CATY_TOKEN"], "issuance used wrong token")
+            _check(method == "POST" and body == b"", "issuance shape differs from contract")
+            return 200, {}, json.dumps({"ok": True, **self.payload}).encode()
+        if path == "/pair/claim":
+            _check(token is None, "claim must be unauthenticated")
+            _check(method == "POST" and body["pair"] == self.payload["pair"], "claim shape differs from contract")
+            _check(body["device"].get("name") == "phone-sim", "claim lacks a display label")
+            if self.claim_status != 200:
+                # Treat even error bodies containing credentials as untrusted.
+                return self.claim_status, {}, json.dumps(self.credentials).encode()
+            return 200, {}, json.dumps({"ok": True, "v": 1, "url": self.payload["url"], "id": self.payload["id"], "token": self.credentials["token"]}).encode()
+        _check(token == self.credentials["token"], "conversation used wrong token")
+        if path == "/health":
+            status = next(self.health)
+            if status is None:
+                raise ConnectionRefusedError("simulated downtime")
+            return status, {}, b"{}"
+        if path == "/talk2":
+            _check(method == "POST" and body == b"", "text turn must have empty body")
+            _check(headers["Content-Length"] == "0", "text turn length missing")
+            _check(headers["X-Session-Id"] == "smoke-mocked", "session changed between turns")
+            text = phone_sim.urllib.parse.unquote(headers["X-Caty-Text"])
+            _check(headers["X-Caty-Text"] == phone_sim.urllib.parse.quote(text, safe=""), "text header is not percent encoded")
+            self.turn += 1
+            if self.turn == 1:
+                self.codeword = re.search(r"blue-[0-9a-f]{6}", text).group()
+            return 200, {}, json.dumps({"id": "job-%d" % self.turn}).encode()
+        _check(method == "GET" and path == "/reply/job-%d" % self.turn, "unexpected reply endpoint")
+        self.polls[path] = self.polls.get(path, 0) + 1
+        if self.polls[path] == 1:
+            return 202, {}, b"{}"
+        reply = self.codeword if self.turn == 3 else "p" * 75 + " ".join(self.credentials.values())
+        return 200, {"x-reply-enc": phone_sim.urllib.parse.quote(reply, safe=""), "x-degraded": "tts"}, b"mp3"
+
+
+def _mock_main(monkeypatch, capsys, gateway, *args):
+    env_text = "CATY_TOKEN=" + gateway.credentials["CATY_TOKEN"] + "\nCATY_PUBLIC_URL=" + gateway.payload["url"]
+    monkeypatch.setattr(phone_sim, "request", gateway.request)
+    monkeypatch.setattr(phone_sim, "read_text", lambda path: env_text if path == "member.env" else "clean logs")
+    monkeypatch.setattr(phone_sim.time, "sleep", lambda seconds: None)
+    result = phone_sim.main(["--env-file", "member.env", "--session-id", "smoke-mocked", *args])
+    captured = capsys.readouterr()
+    _check(all(value not in captured.out + captured.err for value in gateway.credentials.values()), "main disclosed a credential")
+    _check(len(captured.out.splitlines()) == 1, "main output is not a single JSON line")
+    return result, json.loads(captured.out), captured.err
+
+
+def test_main_happy_flow_and_redaction_before_preview(monkeypatch, capsys):
+    gateway = _MockGateway()
+    result, summary, progress = _mock_main(monkeypatch, capsys, gateway, "--no-restart", "--require-recall", "--label", gateway.credentials["CATY_TOKEN"])
+    assert result == 0
+    assert summary["ok"] is True
+    assert summary["stage"] == "done"
+    assert summary["label"] == "[REDACTED]"
+    assert summary["restart"]["observed"] == "skipped"
+    assert summary["resume_recall"] is True
+    assert summary["log_check"] == "skipped"
+    assert gateway.calls.count(("POST", "/pair/new")) == 1
+    assert gateway.calls.count(("POST", "/pair/claim")) == 1
+    assert gateway.calls.count(("POST", "/talk2")) == 3
+    assert all(count == 2 for count in gateway.polls.values())
+    assert len(summary["turns"]) == 3
+    assert all(turn["http_status"] == 200 and turn["degraded"] == "tts" for turn in summary["turns"])
+    assert summary["turns"][0]["reply_preview"] == ("p" * 75 + "[REDACTED]")[:80]
+    assert [line.split()[-1] for line in progress.splitlines()] == ["qr", "claim", "turn1", "turn2", "restart", "turn3", "logcheck", "done"]
+
+
+def test_main_consumed_claim_is_never_retried(monkeypatch, capsys):
+    gateway = _MockGateway(claim_status=409)
+    result, summary, _ = _mock_main(monkeypatch, capsys, gateway, "--no-restart")
+    assert result == 1
+    assert summary["stage"] == "claim"
+    assert summary["claim"]["http_status"] == 409
+    assert gateway.calls.count(("POST", "/pair/claim")) == 1
+    assert summary["turns"] == []
+
+
+def test_main_log_command_leak_is_fatal_and_redacted(monkeypatch, capsys):
+    gateway = _MockGateway()
+    monkeypatch.setattr(phone_sim, "run_command", lambda command, timeout: gateway.credentials["token"])
+    result, summary, _ = _mock_main(monkeypatch, capsys, gateway, "--no-restart", "--log-cmd", "read-logs")
+    assert result == 1
+    assert summary["stage"] == "logcheck"
+    assert summary["log_check"] == "leak"
+    assert summary["log_secret_leak"] is True
+
+
+@pytest.mark.parametrize("health,require,expected_result,observed", [
+    ((200,), False, 0, False), ((200,), True, 1, False),
+    ((None, 503, 200), True, 0, True),
+])
+def test_main_restart_observation(monkeypatch, capsys, health, require, expected_result, observed):
+    gateway = _MockGateway(health=health)
+    commands = []
+    monkeypatch.setattr(phone_sim, "run_command", lambda command, timeout: commands.append(command) or "")
+    args = ["--restart-cmd", "restart-service"]
+    if require:
+        args.append("--require-restart-observed")
+    result, summary, _ = _mock_main(monkeypatch, capsys, gateway, *args)
+    assert result == expected_result
+    assert summary["restart"]["observed"] is observed
+    assert summary["restart"]["downtime_s"] >= 0
+    assert commands == ["restart-service"]
+    assert summary["stage"] == ("restart" if expected_result else "done")
+
+
+def test_main_argparse_error_suppresses_unknown_secrets(capsys):
+    credentials = _credentials()
+    result = phone_sim.main(["--qr-json", "unused", "--unknown", *credentials.values()])
+    captured = capsys.readouterr()
+    _check(all(value not in captured.out + captured.err for value in credentials.values()), "argparse disclosed an argument")
+    assert result == 1
+    assert len(captured.out.splitlines()) == 1
+    assert json.loads(captured.out)["stage"] == "qr"
+
+
+def test_main_env_command_failure_suppresses_unlearned_output(monkeypatch, capsys):
+    credentials = _credentials()
+    def fail_command(command, **kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout=credentials["token"].encode(), stderr=credentials["pair"].encode())
+    monkeypatch.setattr(phone_sim.subprocess, "run", fail_command)
+    result = phone_sim.main(["--env-cmd", "read-member", "--no-restart"])
+    captured = capsys.readouterr()
+    _check(all(value not in captured.out + captured.err for value in credentials.values()), "failed env command disclosed output")
+    assert result == 1
+    assert len(captured.out.splitlines()) == 1
+    assert json.loads(captured.out)["stage"] == "qr"
+
+
+def test_main_malformed_source_does_not_echo_unlearned_secret(monkeypatch, capsys):
+    token = "member-" + secrets.token_hex(12)
+    monkeypatch.setattr(phone_sim, "read_text", lambda path: "CATY_TOKEN=" + token + "\ninvalid assignment")
+    result = phone_sim.main(["--env-file", "member.env", "--label", token,
+                             "--session-id", token, "--no-restart"])
+    captured = capsys.readouterr()
+    _check(token not in captured.out + captured.err, "malformed source disclosed an unlearned secret")
+    assert result == 1
+    assert len(captured.out.splitlines()) == 1
+    assert json.loads(captured.out)["stage"] == "qr"

--- a/tests/test_phone_sim.py
+++ b/tests/test_phone_sim.py
@@ -92,7 +92,7 @@ def test_find_leaks_returns_names_only(name):
     credentials["pair_secret"] = credentials["pair"].split(".")[1]
     result = phone_sim.find_leaks("log prefix " + credentials[name], credentials)
     _check(name in result, "expected leak name absent")
-    _check(all(item in credentials for item in result), "leak detector returned a value")
+    _check(all(item in credentials or item == "pair_pattern" for item in result), "leak detector returned a value")
     _check(all(value not in str(result) for value in credentials.values()), "leak detector disclosed secret")
 
 
@@ -100,6 +100,11 @@ def test_find_leaks_allows_public_pair_id():
     credentials = _credentials()
     credentials["pair_secret"] = credentials["pair"].split(".")[1]
     assert phone_sim.find_leaks(credentials["pair"].split(".")[0], credentials) == []
+    assert phone_sim.find_leaks("pid=deadbeef", credentials) == []
+
+
+def test_find_leaks_generic_pair():
+    assert phone_sim.find_leaks("deadbeef." + "cd" * 16, _credentials()) == ["pair_pattern"]
 
 
 class _FakeOpenAI(http.server.BaseHTTPRequestHandler):
@@ -192,6 +197,7 @@ def _running_gateway(tmp_path):
         home = tmp_path / "home"
         home.mkdir()
         env = {key: value for key, value in os.environ.items() if not key.startswith("CATY_")}
+        env["PYTHONPATH"] = str(ROOT / "src") + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
         env.update({
             "HOME": str(home), "CATY_AGENT": "phone-sim-fake", "CATY_ID": "smoke-e2e",
             "CATY_BACKEND": "openai-compat", "CATY_GATEWAY_BIND": "127.0.0.1",
@@ -208,7 +214,9 @@ def _running_gateway(tmp_path):
         deadline = time.monotonic() + 60
         while not _health(port, token):
             if supervisor.poll() is not None or time.monotonic() >= deadline:
-                pytest.fail("gateway did not become ready; inspect the temporary gateway.log locally")
+                log = tmp_path / "gateway.log"
+                tail = "\n".join(log.read_text(errors="replace").splitlines()[-20:]) if log.exists() else "(no gateway.log)"
+                raise AssertionError("gateway did not become ready:\n" + phone_sim.redact(tail, [token]))
             time.sleep(0.05)
         yield envfile, token
     finally:
@@ -366,6 +374,36 @@ def test_main_consumed_claim_is_never_retried(monkeypatch, capsys):
     assert summary["claim"]["http_status"] == 409
     assert gateway.calls.count(("POST", "/pair/claim")) == 1
     assert summary["turns"] == []
+
+
+def test_main_request_error_suppresses_details(monkeypatch, capsys):
+    gateway = _MockGateway()
+    def fail_request(*args, **kwargs):
+        raise ConnectionRefusedError(gateway.credentials["CATY_TOKEN"])
+    monkeypatch.setattr(gateway, "request", fail_request)
+    result, summary, _ = _mock_main(monkeypatch, capsys, gateway, "--no-restart")
+    assert summary["error"] == "operation failed (ConnectionRefusedError; details suppressed)"
+
+
+def test_main_invalid_session_precedes_env_read(monkeypatch, capsys):
+    gateway = _MockGateway()
+    result, summary, _ = _mock_main(monkeypatch, capsys, gateway, "--no-restart", "--session-id", "bad id", "--env-file", "missing.env")
+    assert result == 1
+    assert gateway.calls == []
+    assert summary["stage"] == "qr"
+    assert summary["error"] == "session id must use only letters, digits, dot, underscore or hyphen"
+
+
+@pytest.mark.parametrize("args,timeout", [((), 60), (("--log-timeout", "37"), 37)])
+def test_main_log_command_timeout(monkeypatch, capsys, args, timeout):
+    def run(command, **kwargs):
+        assert command == "read-logs"
+        assert kwargs["timeout"] == timeout
+        return subprocess.CompletedProcess(command, 0, stdout=b"clean logs")
+    monkeypatch.setattr(phone_sim.subprocess, "run", run)
+    result, summary, _ = _mock_main(monkeypatch, capsys, _MockGateway(), "--no-restart", "--log-cmd", "read-logs", *args)
+    assert result == 0
+    assert summary["log_check"] == "pass"
 
 
 def test_main_log_command_leak_is_fatal_and_redacted(monkeypatch, capsys):

--- a/tools/smoke/phone-sim.py
+++ b/tools/smoke/phone-sim.py
@@ -42,8 +42,11 @@ def redact(text, secrets):
 
 
 def find_leaks(log_text, secrets):
-    """Return only the names of credentials present as plain substrings."""
-    return sorted(name for name, value in secrets.items() if value and value in log_text)
+    """Return only names of known credentials and generic pair patterns."""
+    names = {name for name, value in secrets.items() if value and value in log_text}
+    if PAIR_RE.search(log_text):
+        names.add("pair_pattern")
+    return sorted(names)
 
 
 def parse_env_text(text):
@@ -142,6 +145,7 @@ def make_parser():
     parser.add_argument("--restart-timeout", type=positive_seconds, default=90)
     parser.add_argument("--turn-timeout", type=positive_seconds, default=180)
     parser.add_argument("--claim-timeout", type=positive_seconds, default=15)
+    parser.add_argument("--log-timeout", type=positive_seconds, default=60)
     parser.add_argument("--log-file", action="append", default=[], metavar="PATH")
     parser.add_argument("--log-cmd", action="append", default=[], metavar="CMD")
     parser.add_argument("--session-id", default="smoke-" + time.strftime("%Y%m%d", time.gmtime()) + "-" + secrets.token_hex(3))
@@ -300,6 +304,10 @@ def main(argv):
 
     try:
         args = make_parser().parse_args(argv)
+        if not args.restart_cmd and not args.no_restart:
+            raise SmokeFailure("--restart-cmd or --no-restart is required")
+        if not re.fullmatch(r"[A-Za-z0-9._-]+", args.session_id):
+            raise SmokeFailure("session id must use only letters, digits, dot, underscore or hyphen")
         stage("qr")
         if args.qr_json:
             raw = sys.stdin.read() if args.qr_json == "-" else read_text(args.qr_json)
@@ -315,9 +323,6 @@ def main(argv):
             if not admin_token:
                 raise SmokeFailure("env file requires member token")
             url = validate_url(env.get("CATY_PUBLIC_URL"))
-            # Validate operational arguments before issuing a new credential.
-            if not args.restart_cmd and not args.no_restart:
-                raise SmokeFailure("--restart-cmd or --no-restart is required")
             status, _, raw = request(url, "POST", "/pair/new", token=admin_token,
                                      body=b"", timeout=args.claim_timeout)
             if status != 200:
@@ -332,10 +337,6 @@ def main(argv):
         summary.update(label=args.label, session_id=args.session_id,
                        pair_id=payload["pair"].split(".")[0], member_id=payload["id"],
                        gateway_url=urllib.parse.urlsplit(payload["url"]).netloc)
-        if not args.restart_cmd and not args.no_restart:
-            raise SmokeFailure("--restart-cmd or --no-restart is required")
-        if not re.fullmatch(r"[A-Za-z0-9._-]+", args.session_id):
-            raise SmokeFailure("session id must use only letters, digits, dot, underscore or hyphen")
         stage("claim")
         started = time.monotonic()
         try:
@@ -388,7 +389,7 @@ def main(argv):
                         summary.update(log_check="leak", log_secret_leak=True)
                         raise SmokeFailure("secret detected in logs (content suppressed)")
                 for command in args.log_cmd:
-                    if find_leaks(run_command(command, args.claim_timeout), known):
+                    if find_leaks(run_command(command, args.log_timeout), known):
                         summary.update(log_check="leak", log_secret_leak=True)
                         raise SmokeFailure("secret detected in logs (content suppressed)")
             except Exception:
@@ -405,7 +406,7 @@ def main(argv):
         # Library exceptions may include request headers, file contents, or
         # subprocess output, including credentials not learned yet.
         summary["error"] = (redact(str(error), known) if isinstance(error, SmokeFailure)
-                            else "operation failed (details suppressed)")
+                            else "operation failed (%s; details suppressed)" % type(error).__name__)
     summary["finished_at"] = utc_now()
     print(json.dumps(sanitize_summary(summary, known), ensure_ascii=False, separators=(",", ":"), sort_keys=True))
     return 0 if summary["ok"] else 1

--- a/tools/smoke/phone-sim.py
+++ b/tools/smoke/phone-sim.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Play the CatyPhone role for layer A: pair, text turns, restart, and log audit.
+
+Credentials are read as data, never sourced into a shell. HTTP redirects are not
+followed, and a claim is never retried. Only the final sanitized summary goes to
+stdout; progress contains fixed stage names, never remote bodies or commands.
+"""
+
+import argparse
+import http.client
+import json
+import re
+import secrets
+import shlex
+import subprocess
+import sys
+import time
+import urllib.parse
+
+
+class SmokeFailure(ValueError):
+    """A fixed, safe diagnostic owned by this client."""
+
+
+PAIR_RE = re.compile(r"\b[0-9a-f]{8}\.[0-9a-f]{32}\b")
+
+
+def redact(text, secrets):
+    """Replace known values simultaneously, plus any contract-shaped pair."""
+    values = secrets.values() if isinstance(secrets, dict) else secrets
+    values = {value for value in values if isinstance(value, str) and value}
+    patterns = [re.escape(value) for value in sorted(values, key=len, reverse=True)]
+    pattern = "|".join(patterns + [PAIR_RE.pattern])
+
+    def replacement(match):
+        value = match.group()
+        if value in values:
+            return "[REDACTED]"
+        return value.split(".", 1)[0] + ".[REDACTED]"
+
+    return re.sub(pattern, replacement, str(text))
+
+
+def find_leaks(log_text, secrets):
+    """Return only the names of credentials present as plain substrings."""
+    return sorted(name for name, value in secrets.items() if value and value in log_text)
+
+
+def parse_env_text(text):
+    """Parse single-line shell-style assignments without evaluation/expansion."""
+    result = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = re.sub(r"^export\s+", "", line)
+        match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)", line)
+        if not match:
+            raise SmokeFailure("invalid env assignment")
+        try:
+            words = shlex.split(match[2], comments=True, posix=True)
+        except ValueError:
+            raise SmokeFailure("invalid env quoting") from None
+        if len(words) > 1:
+            raise SmokeFailure("env values containing spaces must be quoted")
+        result[match[1]] = words[0] if words else ""
+    return result
+
+
+def validate_url(value):
+    if not isinstance(value, str) or not value or re.search(r"[\s\x00-\x1f\x7f]", value):
+        raise SmokeFailure("invalid gateway URL")
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+        valid = (
+            parsed.scheme in ("http", "https") and parsed.hostname
+            and parsed.username is None and parsed.password is None
+            and "?" not in value and "#" not in value
+            and "\\" not in value and (port is None or port > 0)
+        )
+    except ValueError:
+        valid = False
+    if not valid:
+        raise SmokeFailure("invalid gateway URL")
+    return value
+
+
+def validate_qr_payload(obj):
+    """Validate contract v1; errors contain no input values."""
+    if not isinstance(obj, dict) or type(obj.get("v")) is not int or obj["v"] != 1:
+        raise SmokeFailure("QR version must be integer 1")
+    validate_url(obj.get("url"))
+    if not isinstance(obj.get("pair"), str) or not PAIR_RE.fullmatch(obj["pair"]):
+        raise SmokeFailure("invalid QR pairing credential")
+    if not isinstance(obj.get("id"), str) or not obj["id"].strip():
+        raise SmokeFailure("QR member id must be non-empty")
+    return {key: obj[key] for key in ("v", "url", "pair", "id")}
+
+
+def utc_now():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def build_summary(*, label="", session_id="", started_at=None):
+    return {
+        "ok": False, "stage": "qr", "stages": [], "label": label, "layer": "A",
+        "session_id": session_id, "pair_id": None, "member_id": None,
+        "gateway_url": None, "claim": {"http_status": None, "latency_s": None},
+        "turns": [], "restart": {"observed": "skipped", "downtime_s": None},
+        "resume_recall": None, "log_check": "skipped", "log_secret_leak": None,
+        "warnings": [], "error": None, "started_at": started_at or utc_now(),
+        "finished_at": None,
+    }
+
+
+class SafeParser(argparse.ArgumentParser):
+    def error(self, message):
+        # argparse's default error includes unknown arguments and their values.
+        raise SmokeFailure("invalid arguments; use --help for usage")
+
+
+def positive_seconds(value):
+    try:
+        number = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("timeout must be positive and finite") from None
+    if not 0 < number < float("inf"):
+        raise argparse.ArgumentTypeError("timeout must be positive and finite")
+    return number
+
+
+def make_parser():
+    parser = SafeParser(prog="phone-sim", description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--qr-json", metavar="PATH", help="QR JSON file; - reads stdin")
+    source.add_argument("--env-file", metavar="PATH", help="member env file (read as data)")
+    source.add_argument("--env-cmd", metavar="CMD", help="command producing member env text")
+    restart = parser.add_mutually_exclusive_group()
+    restart.add_argument("--restart-cmd", metavar="CMD", help="required unless --no-restart")
+    restart.add_argument("--no-restart", action="store_true")
+    parser.add_argument("--restart-timeout", type=positive_seconds, default=90)
+    parser.add_argument("--turn-timeout", type=positive_seconds, default=180)
+    parser.add_argument("--claim-timeout", type=positive_seconds, default=15)
+    parser.add_argument("--log-file", action="append", default=[], metavar="PATH")
+    parser.add_argument("--log-cmd", action="append", default=[], metavar="CMD")
+    parser.add_argument("--session-id", default="smoke-" + time.strftime("%Y%m%d", time.gmtime()) + "-" + secrets.token_hex(3))
+    parser.add_argument("--label", default="")
+    parser.add_argument("--require-recall", action="store_true")
+    parser.add_argument("--require-restart-observed", action="store_true")
+    parser.add_argument("--require-log-check", action="store_true")
+    return parser
+
+
+def read_text(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def run_command(command, timeout):
+    # Never include a command, its stderr, or TimeoutExpired.output in an error:
+    # these can contain credentials that have not yet been learned.
+    result = subprocess.run(command, shell=True, capture_output=True, timeout=timeout)
+    if result.returncode:
+        raise SmokeFailure("command failed (output suppressed)")
+    return result.stdout.decode("utf-8", errors="replace")
+
+
+def request(url, method, path, *, token=None, headers=None, body=None, timeout=15):
+    parsed = urllib.parse.urlsplit(url)
+    connection_type = http.client.HTTPSConnection if parsed.scheme == "https" else http.client.HTTPConnection
+    connection = connection_type(parsed.hostname, parsed.port, timeout=timeout)
+    request_headers = {"Connection": "close", **(headers or {})}
+    if token:
+        request_headers["Authorization"] = "Bearer " + token
+    if isinstance(body, dict):
+        body = json.dumps(body).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    try:
+        connection.request(method, parsed.path.rstrip("/") + path, body=body, headers=request_headers)
+        response = connection.getresponse()
+        return response.status, {key.lower(): value for key, value in response.getheaders()}, response.read()
+    finally:
+        connection.close()
+
+
+def json_object(raw):
+    try:
+        obj = json.loads(raw)
+    except (ValueError, UnicodeError):
+        raise SmokeFailure("invalid JSON response or input") from None
+    if not isinstance(obj, dict):
+        raise SmokeFailure("expected a JSON object")
+    return obj
+
+
+def remember_pair(obj, known):
+    value = obj.get("pair")
+    if isinstance(value, str) and value:
+        known["pair"] = value
+        if "." in value:
+            known["pair_secret"] = value.split(".", 1)[1]
+
+
+def remaining(deadline):
+    value = deadline - time.monotonic()
+    if value <= 0:
+        raise SmokeFailure("stage timed out")
+    return value
+
+
+def pause(deadline):
+    time.sleep(min(0.5, remaining(deadline)))
+
+
+def do_turn(args, payload, token, text, result, known):
+    started = time.monotonic()
+    deadline = started + args.turn_timeout
+    try:
+        status, _, raw = request(
+            payload["url"], "POST", "/talk2", token=token, body=b"",
+            headers={"X-Session-Id": args.session_id,
+                     "X-Caty-Text": urllib.parse.quote(text, safe=""), "Content-Length": "0"},
+            timeout=remaining(deadline),
+        )
+        result["http_status"] = status
+        if status != 200:
+            raise SmokeFailure("text submission failed (HTTP %d)" % status)
+        job = json_object(raw).get("id")
+        if not isinstance(job, str) or not job:
+            raise SmokeFailure("text submission returned no job id")
+        while True:
+            status, headers, _ = request(
+                payload["url"], "GET", "/reply/" + urllib.parse.quote(job, safe=""),
+                token=token, timeout=remaining(deadline),
+            )
+            result["http_status"] = status
+            if status == 200:
+                reply = (urllib.parse.unquote(headers["x-reply-enc"])
+                         if "x-reply-enc" in headers else headers.get("x-reply", ""))
+                result.update(reply_chars=len(reply), reply_preview=redact(reply, known)[:80],
+                              degraded=headers.get("x-degraded") or None)
+                return reply
+            if status != 202:
+                raise SmokeFailure("reply failed (HTTP %d)" % status)
+            pause(deadline)
+    finally:
+        result["latency_s"] = round(time.monotonic() - started, 3)
+
+
+def do_restart(args, payload, token, summary):
+    if args.no_restart:
+        summary["warnings"].append("restart skipped; turn 3 does not prove persistence across restart")
+        if args.require_restart_observed:
+            raise SmokeFailure("restart observation required but restart skipped")
+        return
+    result = summary["restart"] = {"observed": False, "downtime_s": None}
+    deadline = time.monotonic() + args.restart_timeout
+    run_command(args.restart_cmd, remaining(deadline))
+    down_since = None
+    while True:
+        probe_started = time.monotonic()
+        try:
+            status, _, _ = request(payload["url"], "GET", "/health", token=token,
+                                   timeout=min(0.5, remaining(deadline)))
+        except (OSError, http.client.HTTPException):
+            status = None
+        if status == 200:
+            result["downtime_s"] = round(time.monotonic() - down_since, 3) if down_since is not None else 0.0
+            if not result["observed"]:
+                summary["warnings"].append("restart not observed; health was already 200 after command")
+                if args.require_restart_observed:
+                    raise SmokeFailure("restart was not observed")
+            return
+        result["observed"] = True
+        if down_since is None:
+            down_since = probe_started
+        result["downtime_s"] = round(time.monotonic() - down_since, 3)
+        pause(deadline)
+
+
+def sanitize_summary(value, known):
+    if isinstance(value, str):
+        return redact(value, known)
+    if isinstance(value, list):
+        return [sanitize_summary(item, known) for item in value]
+    if isinstance(value, dict):
+        return {key: sanitize_summary(item, known) for key, item in value.items()}
+    return value
+
+
+def main(argv):
+    summary = build_summary()
+    known = {}
+
+    def stage(name):
+        summary["stage"] = name
+        summary["stages"].append(name)
+        print("[phone-sim] " + name, file=sys.stderr)
+
+    try:
+        args = make_parser().parse_args(argv)
+        stage("qr")
+        if args.qr_json:
+            raw = sys.stdin.read() if args.qr_json == "-" else read_text(args.qr_json)
+            obj = json_object(raw)
+            remember_pair(obj, known)
+            payload = validate_qr_payload(obj)
+        else:
+            text = read_text(args.env_file) if args.env_file else run_command(args.env_cmd, args.claim_timeout)
+            env = parse_env_text(text)
+            admin_token = env.get("CATY_TOKEN", "")
+            if admin_token:
+                known["CATY_TOKEN"] = admin_token
+            if not admin_token:
+                raise SmokeFailure("env file requires member token")
+            url = validate_url(env.get("CATY_PUBLIC_URL"))
+            # Validate operational arguments before issuing a new credential.
+            if not args.restart_cmd and not args.no_restart:
+                raise SmokeFailure("--restart-cmd or --no-restart is required")
+            status, _, raw = request(url, "POST", "/pair/new", token=admin_token,
+                                     body=b"", timeout=args.claim_timeout)
+            if status != 200:
+                raise SmokeFailure("pair issuance failed (HTTP %d)" % status)
+            obj = json_object(raw)
+            remember_pair(obj, known)
+            if obj.get("ok") is not True:
+                raise SmokeFailure("pair issuance was not successful")
+            payload = validate_qr_payload(obj)
+        # Do not echo free-form fields until the credential source was parsed.
+        # A malformed source may contain a secret we have not learned yet.
+        summary.update(label=args.label, session_id=args.session_id,
+                       pair_id=payload["pair"].split(".")[0], member_id=payload["id"],
+                       gateway_url=urllib.parse.urlsplit(payload["url"]).netloc)
+        if not args.restart_cmd and not args.no_restart:
+            raise SmokeFailure("--restart-cmd or --no-restart is required")
+        if not re.fullmatch(r"[A-Za-z0-9._-]+", args.session_id):
+            raise SmokeFailure("session id must use only letters, digits, dot, underscore or hyphen")
+        stage("claim")
+        started = time.monotonic()
+        try:
+            status, _, raw = request(payload["url"], "POST", "/pair/claim",
+                                     body={"pair": payload["pair"],
+                                           "device": {"name": "phone-sim", "platform": "layer A"}},
+                                     timeout=args.claim_timeout)
+            summary["claim"]["http_status"] = status
+        finally:
+            summary["claim"]["latency_s"] = round(time.monotonic() - started, 3)
+        if status != 200:
+            raise SmokeFailure("pair claim failed (HTTP %d); not retried" % status)
+        claimed = json_object(raw)
+        token = claimed.get("token")
+        if isinstance(token, str) and token:
+            known["token"] = token
+        if claimed.get("ok") is not True or not isinstance(token, str) or not token.strip():
+            raise SmokeFailure("invalid pair claim response")
+        for key in ("url", "id"):
+            if claimed.get(key) != payload[key]:
+                summary["warnings"].append("claim response " + key + " differs from QR")
+        codeword = "blue-" + secrets.token_hex(3)
+        texts = [
+            'Remember this codeword and answer only "OK": ' + codeword,
+            "Reply with one short sentence: what can you help me with?",
+            "What was the codeword I gave you earlier in this conversation? Reply with only the codeword.",
+        ]
+        for n, text in enumerate(texts, 1):
+            if n == 3:
+                stage("restart")
+                do_restart(args, payload, token, summary)
+            stage("turn%d" % n)
+            turn = {"n": n, "http_status": None, "latency_s": None,
+                    "reply_chars": 0, "reply_preview": "", "degraded": None}
+            summary["turns"].append(turn)
+            reply = do_turn(args, payload, token, text, turn, known)
+            if n == 3:
+                summary["resume_recall"] = codeword.lower() in reply.lower()
+                if not summary["resume_recall"]:
+                    summary["warnings"].append("turn 3 did not recall the codeword")
+                    if args.require_recall:
+                        raise SmokeFailure("resume recall required but codeword was not recalled")
+        stage("logcheck")
+        if args.log_file or args.log_cmd:
+            summary.update(log_check="pass", log_secret_leak=False)
+            # A failed source fails the stage; never call a partial audit a pass.
+            try:
+                for path in args.log_file:
+                    if find_leaks(read_text(path), known):
+                        summary.update(log_check="leak", log_secret_leak=True)
+                        raise SmokeFailure("secret detected in logs (content suppressed)")
+                for command in args.log_cmd:
+                    if find_leaks(run_command(command, args.claim_timeout), known):
+                        summary.update(log_check="leak", log_secret_leak=True)
+                        raise SmokeFailure("secret detected in logs (content suppressed)")
+            except Exception:
+                if not summary["log_secret_leak"]:
+                    summary.update(log_check="skipped", log_secret_leak=None)
+                raise
+        else:
+            summary["warnings"].append("no log source provided; secret leakage was not checked")
+            if args.require_log_check:
+                raise SmokeFailure("log check required but no log source provided")
+        stage("done")
+        summary["ok"] = True
+    except (Exception, KeyboardInterrupt) as error:
+        # Library exceptions may include request headers, file contents, or
+        # subprocess output, including credentials not learned yet.
+        summary["error"] = (redact(str(error), known) if isinstance(error, SmokeFailure)
+                            else "operation failed (details suppressed)")
+    summary["finished_at"] = utc_now()
+    print(json.dumps(sanitize_summary(summary, known), ensure_ascii=False, separators=(",", ":"), sort_keys=True))
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #31 (child of #2).

## What changed

- `tools/smoke/phone-sim.py` (new, stdlib only): plays the CatyPhone role for the phone-less smoke. Reads a QR payload file **or** a member env file / `--env-cmd` (self-issues via authenticated `POST /pair/new`), makes exactly one `POST /pair/claim` attempt (never retried), runs three text turns on `POST /talk2` + `GET /reply/<id>` with one session id, runs `--restart-cmd` before turn 3 and measures the health outage, checks that turn 3 recalls turn 1's codeword (resume probe), then scans `--log-file` / `--log-cmd` output for the pairing secret (full and 32-hex half) and the client token. Exactly one redacted JSON line on stdout, exit 0/1. No `os.environ` access, no new env var.
- `tests/test_phone_sim.py` (new): pure-function tests (env parsing, QR validation without echoing the secret, `redact`, `find_leaks`), mocked-gateway flow tests (claim 409 never retried, restart observation matrix, argparse/env-cmd failures suppress unlearned secrets) and two e2e tests that run the **real gateway** as a subprocess under a respawning supervisor against a fake OpenAI-compatible server: full round trip (restart observed, recall true, token absent from phone-sim stdout/stderr) and a negative control where a seeded log makes the leak detector fire.
- `docs/smoke/README.md` (new): the seven §4-3 steps split into layer A (Alpha, this tool) and layer B (owner, phone), per-route commands for the six routes, same-host / remote-tailnet invocations (Linux env file, macOS plist extraction), the ssh-driven `setup` note (`--yes`, `CATY_QR_DELIVERY=tty`), and the record template.
- `docs/smoke/*-2026-09-06.md` (new, 5 records, `layer: A`): ollama@mac-mini **PASS**; codex@mac-mini FAIL at turn 1 (host account's Codex usage limit, reproduced outside the gateway); claude@mac-mini FAIL at turn 1 (Claude CLI not logged in; doctor's WARN predicted it); openclaw@mac-mini NOT RUN (host no longer runs an OpenClaw gateway, doctor said so); hermes@hetzner-vps NOT RUN (host not reachable from the automated session).
- `Makefile`: optional `smoke-a` target (`$(PYTHON) -B tools/smoke/phone-sim.py $(SMOKE_ARGS)`).

`src/` untouched. No gateway behaviour changes.

## Why

#2 was gated on the owner's phone for all seven steps of every route, so nothing had been measured since v0.1.0. Five of the seven steps are pure HTTP against the pairing and turn contracts and can be driven by a script from a second host. Splitting them off lets install/backend problems surface now (this lane already found two doc/UX gaps and two environment blockers on a real second host) and shrinks the owner's part to QR + one spoken turn + one resume per route.

## Files touched (declared set = diff)

`tools/smoke/phone-sim.py`, `tests/test_phone_sim.py`, `docs/smoke/README.md`, `docs/smoke/{ollama,codex,claude,openclaw}-mac-mini-2026-09-06.md`, `docs/smoke/hermes-hetzner-vps-2026-09-06.md`, `Makefile` — exactly the WIP declaration on #31. Non-overlapping with #28 (PR #32) and #12 (PR #33).

## 完了記録 (Completion record)

candidate SHA: de66cbf (= reviewed 3f8df23 + delta-1 adopting every seat request; `git diff 3f8df23..de66cbf` = 3 files, +59 / −20)
implementer: Codex (GPT-6 Astra, `--profile astra`, sandbox workspace-write) for `phone-sim.py` / `test_phone_sim.py` / README / Makefile; Alpha (Claude Code / Fable 5.1) for the five records, the README ssh note, the layer A run itself, and the commits (identity alpha-mbp-bridge)
reviewer: Grok 4.6 (GO-WITH-MINOR: 2 MINOR + 2 NIT, all adopted) / Kimi K3 (GO: 4 NIT, Q7 recommendation adopted) / Gemini 3.8 Flash (GO-WITH-MINOR: 1 MINOR + 2 NIT, all adopted) — F1–F5 and Q6 PASS from all three at 3f8df23
identity check: 別モデル（writer = Codex GPT-6 Astra; seats per `loom-seats --size M --absent glm-5.3 --absent codex-sol --absent opus-5` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`; GLM 5.3 absent with 429 quota until 2026-09-10; Opus 5 excluded as same family as the orchestrator）
CI: at de66cbf (2026-09-06): `test-lint / test`, `test-lint / test-macos`, `test-lint / lint` (https://github.com/caty-ai/caty-gateway/actions/runs/34049366370), `package-check` (https://github.com/caty-ai/caty-gateway/actions/runs/34049366201), `gitleaks`, `history-check`, `watch`, `risk-review-gate / detect-risk-paths`, `apply-visibility-labels` all PASS. Red by design, both owner labels: `risk-review-gate / risk-review-gate` (this repo lists `tools/**` and `Makefile` as risk paths → `needs-risk-review` was auto-attached; https://github.com/caty-ai/caty-gateway/actions/runs/34049366363/job/101530089693) and `pr-size / pr-size` (measured 1266 lines vs limit 250 — three new files plus five records; https://github.com/caty-ai/caty-gateway/actions/runs/34049366384/job/101530067475). Note: the `size-exempt` label is voided by any new push, so apply it on the final head.
negative control: `tests/test_phone_sim.py::test_e2e_phone_sim_detects_log_leak` seeds the token into the log file phone-sim audits → exit 1, `log_check: "leak"`, `log_secret_leak: true`, `stage: "logcheck"`, and the value still does not appear in phone-sim's output (runs green locally, see below). Field probe on the real host: `--log-cmd false` (a failing log source) → `log_check: "skipped"`, `ok: false`, exit 1 — a broken log read cannot be reported as a pass.
release: N/A（③ tooling, tests and records only — the shipped package (`src/`, pyproject, workflows) is byte-identical; no artifact, behaviour or user-facing norm changes）
previous release: v0.1.4 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.4（履行済み・PyPI https://pypi.org/project/caty-gateway/0.1.4/ ）

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| 1. stdlib-only `tools/smoke/phone-sim.py`: claim → 2 turns → restart → 3rd turn (resume) → token/pair never in log or stdout; exit 0/1 with machine-readable summary | PASS | file in diff; `grep -n "os.environ\|getenv" tools/smoke/phone-sim.py` = 0; e2e round trip green; real run summary in `docs/smoke/ollama-mac-mini-2026-09-06.md` |
| 2. `docs/smoke/README.md`: 7 steps split into layer A / layer B, exact commands per route, record template | PASS | `docs/smoke/README.md` (layer table, six route sections, three invocation blocks, template) |
| 3. Layer A run once on a non-dev host, records committed with `layer: A` | PASS (1 route PASS, 2 env-blocked, 2 not run — all recorded) | mac-mini (family host, caty-gateway 0.1.4 from PyPI in an isolated `UV_TOOL_DIR`, driven from the MBP over the tailnet): https://github.com/caty-ai/caty-gateway/blob/de66cbf/docs/smoke/ollama-mac-mini-2026-09-06.md — all 7 steps PASS, restart outage 0.545 s, `resume_recall: true`, `log_check: pass`. codex / claude / openclaw / hermes records state the exact blocker. |
| 4. Bugs found listed on #2, fixed in separate S/M Issues | PASS (no gateway bug; 2 doc/UX gaps listed) | #2 comment https://github.com/caty-ai/caty-gateway/issues/2#issuecomment-5560946106 (filed as #34 docs and #35 status Detail line: https://github.com/caty-ai/caty-gateway/issues/2#issuecomment-5560950645): (a) `setup` needs `--yes` when stdin is not a TTY — not in Quick Start; (b) `status --member` keeps a stale `Detail:` line after a later success. Both S, filed as #34 (docs) and #35 (status output); neither blocks this lane. |
| 5. Layer B one-screen checklist per route posted on #2 | PASS | #2 comment https://github.com/caty-ai/caty-gateway/issues/2#issuecomment-5560982308 |

Local at candidate: `pytest tests` (with the two #28 deselects) **1188 passed, 2 deselected, 252 subtests** (1155 on main + 33 new); `scrub-audit` 0 findings; `make env-check gate lint` green (`env-inventory: 122 names, no drift`); no `__pycache__` committed.

### Review (3 seats, fresh context, blind, read-only; packet = brief + candidate diff + pairing-v1 contract + server handler excerpts; F1–F5 + Q6 contract deviation + Q7 error-text trade-off)

All three seats reviewed candidate `3f8df23`; every finding was adopted in `de66cbf` (delta-1, Codex astra, +59/−20 across the three declared code/doc files; records untouched). No CRITICAL / MAJOR from any seat.

- **Grok 4.6** (tools, ran `--help`, the qr negative case, `-k e2e` with `PYTHONPATH=src` → 2 passed, hygiene greps) — GO-WITH-MINOR. MINOR: e2e fixture depends on an installed package / `PYTHONPATH` and loses the gateway log on readiness failure → **adopted** (fixture prepends `<repo>/src`, quotes the log tail). MINOR: `--session-id` validated after `POST /pair/new`, so a typo burns a live credential → **adopted** (validated before any request; new test proves zero requests). NIT: `find_leaks` ignores the generic pair regex → **adopted** (`pair_pattern`). NIT: per-route README blocks lacked `--yes` / `CATY_QR_DELIVERY=tty` → **adopted**. Q7: keep `str(error)` suppressed; class name optional.
- **Kimi K3** (tools, ran the full `test_phone_sim.py`: 26 pass + 2 e2e env-fail on bare python, then `PYTHONPATH=src -k e2e` → 2 passed; env-inventory, scrub, hygiene greps) — GO. NITs only (e2e needs the package importable — same as the pre-existing process fixture; outage during the restart command itself is invisible — documented behaviour; substring-only leak scan — generic regex now added; the e2e cannot learn the claim token — covered by the mock-flow test). Q7: add `type(error).__name__` → **adopted**.
- **Gemini 3.8 Flash** (static, inline packet, no tools) — GO-WITH-MINOR. MINOR: add the exception class name → **adopted**. NIT: `--log-cmd` reused `--claim-timeout` → **adopted** (`--log-timeout`, default 60 s). NIT: `find_leaks` lacks the generic pattern → **adopted**.
- F1–F5 and Q6: PASS from all three seats independently (protocol fidelity against the real handlers, no secret path, honest summary, scope, docs/records). Convergence: two seats independently asked for the generic pair pattern; two independently asked for the exception class name.
- **Alpha's disposition (writer-side orchestrator, not a vote):** candidate `de66cbf`. Delta re-verified locally: `test_phone_sim.py` 33 passed (incl. both e2e), scrub 0, env-inventory no drift, gate OK; the real-host run on the mini was repeated twice after the delta: claim / turns / restart (0.53 s, 0.64 s outage) / log check all behaved identically, but the 2.4B granite model answered the recall question with "OK" both times, so `--require-recall` made those re-runs exit 1 (2 hits / 2 misses across the 4 runs today). The on-disk history file shows turn 3 appended to the same session after the restart, i.e. the gateway resume path works; the miss is model behaviour and the tool reported it truthfully. The committed PASS record is the 17:06Z run whose recall succeeded.

### Owner actions

1. Labels on this PR (owner): `risk-reviewed` (risk paths = `tools/smoke/phone-sim.py`, `Makefile`; the review packet and three seats above are the risk review) and `size-exempt` (1266 lines; nothing to split — the tool, its test and the records belong together). https://github.com/caty-ai/caty-gateway/pull/36
2. Merge (squash). No tag, no release (N/A ③).
3. Layer B whenever convenient, one route at a time — checklist on #2. The three `smoke-*` services stay installed on the mini for that; `smoke-codex` needs the host account's Codex quota to reset and `smoke-claude` needs `claude` → `/login` on the mini before their layer A can be re-run.

### Not in this lane

Layer B itself, voice/STT/TTS quality, vLLM / LiteLLM / OpenRouter, LM Studio install, gateway bug fixes (separate Issues), Cero's Hermes configuration, PyPI publish, tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
