### PR TITLE
fix: status --member no longer shows the Detail: line of an earlier failed attempt after a successful setup (#35)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "caty-gateway"
-version = "0.1.4"
+version = "0.1.5"
 description = "A self-hosted voice and pairing gateway for Caty clients"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/src/caty_gateway/setup_orchestrator.py
+++ b/src/caty_gateway/setup_orchestrator.py
@@ -1930,7 +1930,7 @@ class SetupOrchestrator:
             "completed_phases": list(self.state.completed_phases),
             "timeline_entry": "setup run started",
             "clear_fields": (
-                "qr_url",
+                "message", "qr_url",
                 "expires_at",
                 "recovery_pointer",
                 "resume_output",
@@ -1993,7 +1993,7 @@ class SetupOrchestrator:
             terminal=True,
             phase="complete",
             completed_phases=list(PHASES),
-            timeline_entry="setup completed",
+            message="setup completed", timeline_entry="setup completed",
             clear_fields=("qr_url", "expires_at", "recovery_pointer", *OWNER_FIELDS),
         )
         effective_qr_delivery = self.qr_delivery

--- a/tests/test_setup_orchestrator.py
+++ b/tests/test_setup_orchestrator.py
@@ -2624,6 +2624,42 @@ def test_orchestrator_owner_fields_clear_on_normal_completion(fake_home, tmp_pat
     assert all(field not in payload for field in setup_orchestrator.OWNER_FIELDS)
 
 
+def test_orchestrator_success_replaces_previous_failure_detail(fake_home, tmp_path, monkeypatch, capsys):
+    failed_orch = _make_orch(
+        fake_home, tmp_path, monkeypatch, "--public-url", "http://100.64.0.1:8788",
+    )
+    failure_message = "stdin is not interactive; rerun with --yes to accept the plan"
+    failed_orch._update_status(
+        state="failed",
+        active=False,
+        terminal=True,
+        message=failure_message,
+        timeline_entry="setup failed",
+    )
+    assert failed_orch._read_status()["message"] == failure_message
+
+    orch = _make_orch(
+        fake_home, tmp_path, monkeypatch, "--yes", "--public-url", "http://100.64.0.1:8788",
+    )
+    assert orch.status_path == failed_orch.status_path
+    orch._preflight = lambda: setattr(orch, "config", orch._resolved_config())
+    orch._backend = lambda: True
+    orch._install = lambda: None
+    orch._start = lambda: None
+    orch._linger = lambda: None
+    orch._health = lambda: None
+    orch._identity = lambda: None
+    orch._qr = lambda: None
+
+    assert orch.run() == 0
+    assert orch._read_status()["state"] == "succeeded"
+    capsys.readouterr()
+    orch._print_status(orch._read_status())
+    output = capsys.readouterr().out
+    assert not any(line.startswith("Detail: stdin is not interactive") for line in output.splitlines())
+    assert "Detail: setup completed" in output
+
+
 @pytest.mark.parametrize(
     ("raised", "expected_state"),
     [


### PR DESCRIPTION
Lane for #35 (size S, patch release ④ → v0.1.5). Closes #35.

## What changed

- `src/caty_gateway/setup_orchestrator.py` (+2/−2, inside `SetupOrchestrator.run()`): the `"setup run started"` status write now lists `message` in its `clear_fields`, so a new attempt never carries a previous attempt's failure text; the final `succeeded` write sets `message="setup completed"` — the same wording the supervised path in `setup_supervisor.py` already writes on success. `_print_status()`, `update_status()` merge semantics, env variables and the supervisor are untouched.
- `tests/test_setup_orchestrator.py` (+36): `test_orchestrator_success_replaces_previous_failure_detail` — seeds the failed status through `_update_status` (asserts the failure `message` is really on disk), runs a second `--yes` orchestrator against the same status path with stubbed phases, asserts `state == succeeded`, then `_print_status()` output contains no `Detail: stdin is not interactive` line and does contain `Detail: setup completed`.
- `pyproject.toml`: version `0.1.4` → `0.1.5` (risk path → owner `risk-reviewed`).

## Why

Real host (Mac mini, 0.1.4, #31 layer-A smoke): `setup` over ssh without `--yes` failed with `stdin is not interactive; rerun with --yes to accept the plan`; the rerun with `--yes` succeeded; `status --member` then printed `Setup status … succeeded` / `Current phase: complete` / `Detail: stdin is not interactive …`. `main()` records the failure `message` into the member status JSON and `update_status()` merges, but neither the run-start write nor the success write in `run()` touched `message`. Shipped CLI output changes → patch release.

## Files touched (declared set = diff)

`src/caty_gateway/setup_orchestrator.py`, `tests/test_setup_orchestrator.py`, `pyproject.toml` — `git diff --stat origin/main...e03a7f4` (main = `fc52096`): 3 files, +39 / −3. The `.omx/` line the Codex sandbox appends to `.gitignore` was reverted before handoff. Nothing under `docs/`, `docs/smoke/`, `tools/smoke/`, `setup_supervisor.py`.

## 完了記録 (Completion record)

candidate SHA: e03a7f4
implementer: Codex (GPT-6 Astra, medium, `--profile astra --sandbox workspace-write`, via sitter-run) — src + test; `pyproject.toml` bump and commit by Alpha as alpha-mbp-bridge
reviewer: Grok 4.6 (GO, 1 NIT) / Kimi K3 (GO, 2 NITs) / Gemini 3.8 Flash (GO, findings none) — all at e03a7f4; no MAJOR, no delta, no second round
identity check: 別モデル（writer = Codex Astra; seats per `loom-seats --size S --absent glm-5.3 --absent codex-sol --absent opus-5` = Grok 4.6 / Kimi K3 / Gemini 3.8 Flash, `status: GO`; glm-5.3 absent with 429 quota until 2026-09-10; codex-sol excluded as same family as the writer; opus-5 excluded as same family as the adjudicator, same as PR #30 / #32）
CI: at e03a7f4 (2026-09-07): `test-lint / test`, `test-lint / test-macos`, `test-lint / lint`, `package-check`, `gitleaks`, `history-check`, `pr-size`, `risk-review-gate / detect-risk-paths`, `apply-visibility-labels`, `watch` all PASS; `risk-review-gate / risk-review-gate` FAIL until the owner applies `risk-reviewed` (`pyproject.toml` is a declared risk path) — https://github.com/caty-ai/caty-gateway/pull/40/checks
negative control: with the two `run()` lines reverted and the test kept, `test_orchestrator_success_replaces_previous_failure_detail` FAILS on `assert not any(line.startswith("Detail: stdin is not interactive") …)` (writer's run; Kimi and Grok re-derived the same failing line by reading, Gemini named both failing assertions). Local full suite at e03a7f4 (macOS, venv): `make test` → **1192 passed, 252 subtests passed**, `suites: declared=56 executed=56 skipped=0`, env inventory no drift, publication gate OK.
release: ④ patch → **v0.1.5**（shipped CLI output changes: `status --member` after a fail→succeed sequence; package version bumped in this PR）. After merge Alpha cuts the annotated tag `v0.1.5` + GitHub Release; PyPI publish is owner-only (`gh workflow run publish.yml --ref v0.1.5 -f version=0.1.5` → approve `pypi`).
previous release: v0.1.4 → https://github.com/caty-ai/caty-gateway/releases/tag/v0.1.4（履行済み・PyPI https://pypi.org/project/caty-gateway/0.1.4/ ）

### Done when → 結果

| Done when 項目 | 結果 | 証拠 |
|---|---|---|
| After a successful run, `status --member` shows no stale `Detail:` from an earlier failed attempt (clear it on success, or scope it to the failing phase) | PASS (both: cleared at run start, replaced on success) | `run()` initial `clear_fields` + `message="setup completed"`; all three seats traced the unsupervised claim (compare-and-set, `_claim_orchestrator_owner`), the supervised `_update_status(**initial_status)` and the resume path — no survival path; the clear is only reached by the flight owner, so a live supervisor's `rolling-back` / `waiting-backend` message cannot be clobbered |
| Regression test: fail → succeed → `status` output has no `Detail:` line (or shows the success detail) | PASS | new test; negative control fails without the fix; first assertion proves the stale message was on disk; `status_path` equality asserted between the two orchestrators |

### Review (3 seats, fresh context, blind, read-only; packet = brief + diff + after-snapshot excerpts of `run()`, `_print_status`, `main()` handlers, `update_status`, supervisor success write, new test + fixture; worktree read-only for context)

- **Grok 4.6** — GO. Verified `OWNER_FIELDS` and the success `clear_fields` tuple unchanged; wait loop keys on `qr_url` / terminal states only; `_backend()` False handoff returns with `message` already cleared and the supervisor filling it. NIT: lines 1933 / 1996 pack two tokens on one line.
- **Kimi K3** — GO. Same trace incl. the supervised early return in `_claim_orchestrator_owner` (harmless: run() writes `initial_status` unconditionally on that path). NITs: `startswith` prefix assertion could be exact-line; `src/caty_gateway/__init__.py` `__version__ = "0.1.0"` drift (unread anywhere; 0.1.1–0.1.4 ignored it too) → follow-up.
- **Gemini 3.8 Flash** (static, inline packet, no tools) — GO, findings none. Confirmed hatchling reads the version from `pyproject.toml` only; recommends `__version__` in a follow-up.
- **Alpha's disposition (writer lane owner, not a vote):** candidate e03a7f4 unchanged. Grok's line-packing NIT and Kimi's exact-line NIT are style at size S and change nothing the test proves; not adopted. The `__version__` drift was raised by all three seats independently → Alpha will open a follow-up Issue (sync or delete; not this patch).

### Owner actions

1. Apply `risk-reviewed` on e03a7f4 (pyproject risk path) → `risk-review-gate` turns green.
2. Merge (squash). Alpha then cuts `v0.1.5` (annotated tag + GitHub Release) and hands over the three PyPI publish lines.

### Not in this lane

`__version__` drift in `__init__.py` (follow-up Issue), `docs/smoke/` and `tools/smoke/` (parallel layer-A lane), #34 / PR #37 (docs lane, owner-merge pending), #12 / PR #33, PyPI publish (owner-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
